### PR TITLE
feat: extract @stentorosaur/core aggregation with golden-file tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build
+        # Build first: the plugin's typecheck resolves @stentorosaur/core
+        # through the workspace symlink to its compiled lib/
+        run: npm run build --workspaces --if-present
+
       - name: Run type check
         run: npx tsc --noEmit -p packages/docusaurus-plugin-stentorosaur
 
       - name: Run tests
         run: npm test --workspaces --if-present -- --coverage
-
-      - name: Build
-        run: npm run build --workspaces --if-present
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Build
         run: npm run build --workspaces --if-present
 
-      - name: Publish to npm
+      - name: Publish @stentorosaur/core to npm
+        # Core publishes FIRST: if this fails (e.g. npm org not configured),
+        # the plugin is never published with an unresolvable dependency.
+        working-directory: packages/core
+        run: npm publish --access public
+
+      - name: Publish plugin to npm
         working-directory: packages/docusaurus-plugin-stentorosaur
         run: npm publish --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -24510,8 +24510,14 @@
     },
     "packages/core": {
       "name": "@stentorosaur/core",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "jest": "^30.2.0",
+        "ts-jest": "^29.4.5",
+        "typescript": "^5.0.0"
+      },
       "engines": {
         "node": ">=20.0"
       }
@@ -24526,6 +24532,7 @@
         "@docusaurus/types": "^3.0.0",
         "@docusaurus/utils": "^3.0.0",
         "@octokit/rest": "^20.0.2",
+        "@stentorosaur/core": "^0.1.0",
         "axios": "^1.13.2",
         "chart.js": "^4.5.1",
         "chartjs-plugin-annotation": "^3.1.0",

--- a/packages/core/__tests__/aggregate.test.ts
+++ b/packages/core/__tests__/aggregate.test.ts
@@ -1,0 +1,180 @@
+import {
+  aggregateDayReadings,
+  aggregateSystem,
+  averageRecentResponseTime,
+  calculateAvgResponseTime,
+  calculateP95,
+  calculateStatusFromUptime,
+  calculateUptimePercent,
+  countIncidentTransitions,
+  formatUptimePercent,
+  groupReadingsByDate,
+  groupReadingsBySystem,
+  sortReadingsDesc,
+} from '../src/aggregate';
+import type {CompactReading} from '../src/types';
+
+const r = (
+  t: number,
+  state: CompactReading['state'],
+  lat: number,
+  code = 200,
+  svc = 'api'
+): CompactReading => ({t, svc, state, code, lat});
+
+describe('groupReadingsBySystem', () => {
+  it('groups by svc preserving insertion order', () => {
+    const readings = [r(1, 'up', 10), {...r(2, 'up', 20), svc: 'web'}, r(3, 'down', 0)];
+    const map = groupReadingsBySystem(readings);
+    expect([...map.keys()]).toEqual(['api', 'web']);
+    expect(map.get('api')!.map(x => x.t)).toEqual([1, 3]);
+  });
+});
+
+describe('sortReadingsDesc', () => {
+  it('sorts most-recent-first without mutating input', () => {
+    const input = [r(1, 'up', 10), r(3, 'up', 30), r(2, 'up', 20)];
+    const sorted = sortReadingsDesc(input);
+    expect(sorted.map(x => x.t)).toEqual([3, 2, 1]);
+    expect(input.map(x => x.t)).toEqual([1, 3, 2]);
+  });
+});
+
+describe('calculateUptimePercent / formatUptimePercent', () => {
+  it('is up-count over total', () => {
+    expect(
+      calculateUptimePercent([r(1, 'up', 1), r(2, 'down', 0), r(3, 'up', 1), r(4, 'up', 1)])
+    ).toBe(75);
+  });
+  it('returns 0 for empty input', () => {
+    expect(calculateUptimePercent([])).toBe(0);
+  });
+  it('maintenance does NOT count as up at system level', () => {
+    expect(calculateUptimePercent([r(1, 'maintenance', 1), r(2, 'up', 1)])).toBe(50);
+  });
+  it('formats with two decimals', () => {
+    expect(formatUptimePercent(100)).toBe('100.00%');
+    expect(formatUptimePercent(2 / 3 * 100)).toBe('66.67%');
+  });
+});
+
+describe('calculateAvgResponseTime', () => {
+  it('averages only up readings with 2xx codes, rounded', () => {
+    const readings = [
+      r(1, 'up', 100, 200),
+      r(2, 'up', 200, 301), // non-2xx: excluded
+      r(3, 'down', 999, 500), // down: excluded
+      r(4, 'up', 101, 204),
+    ];
+    expect(calculateAvgResponseTime(readings)).toBe(Math.round((100 + 101) / 2));
+  });
+  it('returns undefined when no successful readings', () => {
+    expect(calculateAvgResponseTime([r(1, 'down', 5, 500)])).toBeUndefined();
+    expect(calculateAvgResponseTime([])).toBeUndefined();
+  });
+});
+
+describe('averageRecentResponseTime', () => {
+  it('averages the first N entries, rounded', () => {
+    const entries = Array.from({length: 12}, (_, i) => ({responseTime: i + 1}));
+    // first 10: 1..10 → avg 5.5 → round 6
+    expect(averageRecentResponseTime(entries)).toBe(6);
+  });
+  it('handles fewer than N entries and empty input', () => {
+    expect(averageRecentResponseTime([{responseTime: 7}])).toBe(7);
+    expect(averageRecentResponseTime([])).toBeUndefined();
+  });
+});
+
+describe('aggregateSystem', () => {
+  it('produces latest, sorted history, uptime and avg', () => {
+    const agg = aggregateSystem('api', [r(10, 'down', 0, 500), r(20, 'up', 50)]);
+    expect(agg.latest.t).toBe(20);
+    expect(agg.readingsDesc.map(x => x.t)).toEqual([20, 10]);
+    expect(agg.uptimePercent).toBe(50);
+    expect(agg.uptimeFormatted).toBe('50.00%');
+    expect(agg.avgResponseTime).toBe(50);
+  });
+});
+
+describe('calculateStatusFromUptime', () => {
+  it.each([
+    [100, 10, 'operational'],
+    [99, 10, 'operational'],
+    [98.99, 10, 'degraded'],
+    [95, 10, 'degraded'],
+    [94.99, 10, 'outage'],
+    [100, 0, 'no-data'],
+  ] as const)('%s%% over %s checks → %s', (pct, total, expected) => {
+    expect(calculateStatusFromUptime(pct, total)).toBe(expected);
+  });
+});
+
+describe('calculateP95', () => {
+  it('uses nearest-rank on a sorted copy', () => {
+    expect(calculateP95([5, 1, 3])).toBe(5); // ceil(3*0.95)-1 = 2 → sorted[2]
+    expect(calculateP95([1])).toBe(1);
+    expect(calculateP95([])).toBeNull();
+  });
+});
+
+describe('countIncidentTransitions', () => {
+  it('counts up→down transitions only', () => {
+    const readings = [
+      r(1, 'up', 1),
+      r(2, 'down', 0),
+      r(3, 'down', 0),
+      r(4, 'up', 1),
+      r(5, 'down', 0),
+    ];
+    expect(countIncidentTransitions(readings)).toBe(2);
+  });
+});
+
+describe('aggregateDayReadings', () => {
+  it('maintenance counts as passed; latency stats use up readings only', () => {
+    const day = aggregateDayReadings('2026-07-01', [
+      r(1, 'up', 100),
+      r(2, 'maintenance', 0),
+      r(3, 'down', 0, 500),
+      r(4, 'up', 200),
+    ]);
+    expect(day.checksTotal).toBe(4);
+    expect(day.checksPassed).toBe(3);
+    expect(day.uptimeFraction).toBe(0.75);
+    expect(day.avgLatencyMs).toBe(150);
+    expect(day.p95LatencyMs).toBe(200);
+    expect(day.incidentCount).toBe(0); // maintenance breaks the up→down pair
+    expect(day.status).toBe('outage'); // 75% < 95
+  });
+  it('empty day is no-data', () => {
+    const day = aggregateDayReadings('2026-07-01', []);
+    expect(day.status).toBe('no-data');
+    expect(day.uptimeFraction).toBe(0);
+    expect(day.avgLatencyMs).toBeNull();
+  });
+});
+
+describe('groupReadingsByDate', () => {
+  const day1 = Date.UTC(2026, 6, 1, 12);
+  const day2 = Date.UTC(2026, 6, 2, 0, 5);
+  it('groups by UTC date and filters by service case-insensitively', () => {
+    const readings = [
+      r(day1, 'up', 1),
+      {...r(day1 + 1000, 'up', 1), svc: 'API'},
+      {...r(day2, 'up', 1), svc: 'other'},
+      r(day2, 'down', 0),
+    ];
+    const groups = groupReadingsByDate(readings, 'api');
+    expect([...groups.keys()]).toEqual(['2026-07-01', '2026-07-02']);
+    expect(groups.get('2026-07-01')!.length).toBe(2);
+    expect(groups.get('2026-07-02')!.length).toBe(1);
+  });
+  it('includes all services when no filter given', () => {
+    const groups = groupReadingsByDate([
+      r(day1, 'up', 1),
+      {...r(day1, 'up', 1), svc: 'other'},
+    ]);
+    expect(groups.get('2026-07-01')!.length).toBe(2);
+  });
+});

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/__tests__'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,11 +1,34 @@
 {
   "name": "@stentorosaur/core",
-  "private": true,
-  "version": "0.0.0",
-  "description": "Pure schemas and aggregation logic for Stentorosaur (ADR-005). Shell package — populated by epic #63; no entry point until the build tooling lands with the first real module.",
+  "version": "0.1.0",
+  "description": "Pure schemas and aggregation logic for Stentorosaur status monitoring (ADR-005). No I/O.",
   "license": "MIT",
   "author": "Amiable Development <dev@amiable.dev>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amiable-dev/docusaurus-plugin-stentorosaur.git",
+    "directory": "packages/core"
+  },
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "prepare": "npm run build",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "^30.2.0",
+    "ts-jest": "^29.4.5",
+    "typescript": "^5.0.0"
+  },
   "engines": {
     "node": ">=20.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/core/src/aggregate.ts
+++ b/packages/core/src/aggregate.ts
@@ -126,7 +126,12 @@ export function calculateP95(latencies: number[]): number | null {
   return sorted[Math.max(0, index)];
 }
 
-/** Count up→down transitions in reading order. */
+/**
+ * Count up→down transitions in reading order.
+ *
+ * @param readings Must be in **chronological** order (oldest first).
+ *   Passing unsorted readings will produce an inaccurate count.
+ */
 export function countIncidentTransitions(
   readings: CompactReading[]
 ): number {
@@ -142,6 +147,10 @@ export function countIncidentTransitions(
 /**
  * Aggregate one day's readings for one service. 'maintenance' counts as
  * passed; latency statistics consider only 'up' readings.
+ *
+ * @param readings Should be in **chronological** order (oldest first) for an
+ *   accurate `incidentCount`.  The function does not sort internally so that
+ *   callers can avoid unnecessary copies when they already have sorted data.
  */
 export function aggregateDayReadings(
   date: string,

--- a/packages/core/src/aggregate.ts
+++ b/packages/core/src/aggregate.ts
@@ -1,0 +1,206 @@
+/**
+ * Pure aggregation functions extracted from the plugin's four historical
+ * call sites (ADR-005 §1; epic #63 ticket #65):
+ *   - loadContent() reading aggregation        (src/index.ts)
+ *   - convertReadingsToSystemFiles()           (src/index.ts)
+ *   - readSystemFiles() response-time fallback (src/index.ts)
+ *   - StatusDataProvider / useDailySummary day rollups (client)
+ *
+ * Behavior is preserved exactly — the plugin's golden-file test
+ * (packages/docusaurus-plugin-stentorosaur/__tests__/golden/) pins the
+ * end-to-end outputs these functions must reproduce.
+ */
+
+import type {
+  CompactReading,
+  DayAggregate,
+  DayLevelStatus,
+  SystemAggregate,
+  UptimeThresholds,
+} from './types';
+import {DEFAULT_THRESHOLDS} from './types';
+
+/** Group readings by system name (insertion order preserved). */
+export function groupReadingsBySystem(
+  readings: CompactReading[]
+): Map<string, CompactReading[]> {
+  const map = new Map<string, CompactReading[]>();
+  for (const reading of readings) {
+    if (!map.has(reading.svc)) {
+      map.set(reading.svc, []);
+    }
+    map.get(reading.svc)!.push(reading);
+  }
+  return map;
+}
+
+/** Return a copy sorted most-recent-first. */
+export function sortReadingsDesc(
+  readings: CompactReading[]
+): CompactReading[] {
+  return [...readings].sort((a, b) => b.t - a.t);
+}
+
+/** Percentage of readings with state 'up' (0-100); 0 for empty input. */
+export function calculateUptimePercent(readings: CompactReading[]): number {
+  if (readings.length === 0) {
+    return 0;
+  }
+  const upReadings = readings.filter(r => r.state === 'up').length;
+  return (upReadings / readings.length) * 100;
+}
+
+/** Format an uptime percentage as e.g. "99.98%". */
+export function formatUptimePercent(pct: number): string {
+  return `${(Math.round(pct * 100) / 100).toFixed(2)}%`;
+}
+
+/**
+ * Average latency over successful readings (state 'up' AND 2xx code),
+ * rounded to the nearest ms; undefined when there are none.
+ */
+export function calculateAvgResponseTime(
+  readings: CompactReading[]
+): number | undefined {
+  const successful = readings.filter(
+    r => r.state === 'up' && r.code >= 200 && r.code < 300
+  );
+  if (successful.length === 0) {
+    return undefined;
+  }
+  return Math.round(
+    successful.reduce((sum, r) => sum + r.lat, 0) / successful.length
+  );
+}
+
+/**
+ * Average of the first `take` entries' responseTime (entries are assumed
+ * most-recent-first), rounded; undefined for empty input.
+ */
+export function averageRecentResponseTime(
+  entries: Array<{responseTime: number}>,
+  take = 10
+): number | undefined {
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const recent = entries.slice(0, take);
+  const sum = recent.reduce((acc, e) => acc + e.responseTime, 0);
+  return Math.round(sum / recent.length);
+}
+
+/** Full system-level aggregate over one system's readings. */
+export function aggregateSystem(
+  name: string,
+  readings: CompactReading[]
+): SystemAggregate {
+  const readingsDesc = sortReadingsDesc(readings);
+  const uptimePercent = calculateUptimePercent(readings);
+  return {
+    name,
+    readingsDesc,
+    latest: readingsDesc[0],
+    uptimePercent,
+    uptimeFormatted: formatUptimePercent(uptimePercent),
+    avgResponseTime: calculateAvgResponseTime(readings),
+  };
+}
+
+/** Day-level status from uptime percentage (ADR-004 thresholds). */
+export function calculateStatusFromUptime(
+  uptimePercent: number,
+  checksTotal: number,
+  thresholds: UptimeThresholds = DEFAULT_THRESHOLDS
+): DayLevelStatus {
+  if (checksTotal === 0) return 'no-data';
+  if (uptimePercent >= thresholds.operational) return 'operational';
+  if (uptimePercent >= thresholds.degraded) return 'degraded';
+  return 'outage';
+}
+
+/** P95 latency (nearest-rank); null for empty input. */
+export function calculateP95(latencies: number[]): number | null {
+  if (latencies.length === 0) return null;
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const index = Math.ceil(sorted.length * 0.95) - 1;
+  return sorted[Math.max(0, index)];
+}
+
+/** Count up→down transitions in reading order. */
+export function countIncidentTransitions(
+  readings: CompactReading[]
+): number {
+  let incidents = 0;
+  for (let i = 1; i < readings.length; i++) {
+    if (readings[i - 1].state === 'up' && readings[i].state === 'down') {
+      incidents++;
+    }
+  }
+  return incidents;
+}
+
+/**
+ * Aggregate one day's readings for one service. 'maintenance' counts as
+ * passed; latency statistics consider only 'up' readings.
+ */
+export function aggregateDayReadings(
+  date: string,
+  readings: CompactReading[],
+  thresholds: UptimeThresholds = DEFAULT_THRESHOLDS
+): DayAggregate {
+  const checksTotal = readings.length;
+  const checksPassed = readings.filter(
+    r => r.state === 'up' || r.state === 'maintenance'
+  ).length;
+  const uptimeFraction = checksTotal > 0 ? checksPassed / checksTotal : 0;
+
+  const latencies = readings.filter(r => r.state === 'up').map(r => r.lat);
+  const avgLatencyMs =
+    latencies.length > 0
+      ? Math.round(
+          latencies.reduce((sum, lat) => sum + lat, 0) / latencies.length
+        )
+      : null;
+
+  return {
+    date,
+    checksTotal,
+    checksPassed,
+    uptimeFraction,
+    avgLatencyMs,
+    p95LatencyMs: calculateP95(latencies),
+    incidentCount: countIncidentTransitions(readings),
+    status: calculateStatusFromUptime(
+      uptimeFraction * 100,
+      checksTotal,
+      thresholds
+    ),
+  };
+}
+
+/**
+ * Group readings by UTC date (YYYY-MM-DD), optionally filtered to one
+ * service (case-insensitive).
+ */
+export function groupReadingsByDate(
+  readings: CompactReading[],
+  serviceName?: string
+): Map<string, CompactReading[]> {
+  const groups = new Map<string, CompactReading[]>();
+  const lowerServiceName = serviceName?.toLowerCase();
+
+  for (const reading of readings) {
+    if (
+      lowerServiceName !== undefined &&
+      reading.svc.toLowerCase() !== lowerServiceName
+    ) {
+      continue;
+    }
+    const date = new Date(reading.t).toISOString().split('T')[0];
+    if (!groups.has(date)) {
+      groups.set(date, []);
+    }
+    groups.get(date)!.push(reading);
+  }
+  return groups;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,10 +1,10 @@
 /**
  * @stentorosaur/core — pure schemas and aggregation logic (ADR-005 §1).
  *
- * Shell package created by the monorepo scaffold (epic #63, ticket #64).
- * Populated by the core-extraction ticket (#65) and the status/v1 schema
- * ticket (#67). This package must contain NO I/O — pure functions over
- * already-fetched data only.
+ * This package must contain NO I/O — pure functions over already-fetched
+ * data only. Fetching (HTTP, GitHub API, git) belongs in
+ * @stentorosaur/probe; rendering belongs in the Docusaurus plugin.
  */
 
-export {};
+export * from './types';
+export * from './aggregate';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared aggregation types for Stentorosaur (ADR-005 §1).
+ *
+ * These model the compact reading format used by current.json and the
+ * derived aggregates. No I/O types belong here.
+ */
+
+/** One monitoring reading in the compact current.json format. */
+export interface CompactReading {
+  /** Epoch milliseconds of the check */
+  t: number;
+  /** System/service name */
+  svc: string;
+  /** Check outcome state */
+  state: 'up' | 'down' | 'degraded' | 'maintenance';
+  /** HTTP status code observed */
+  code: number;
+  /** Latency in milliseconds */
+  lat: number;
+  /** Optional error message */
+  err?: string;
+}
+
+/** Day-level status classification (ADR-004 thresholds). */
+export type DayLevelStatus = 'operational' | 'degraded' | 'outage' | 'no-data';
+
+/** Uptime thresholds for day-level status classification. */
+export interface UptimeThresholds {
+  /** >= this percentage → operational */
+  operational: number;
+  /** >= this percentage → degraded (below → outage) */
+  degraded: number;
+}
+
+/** ADR-004 default thresholds. */
+export const DEFAULT_THRESHOLDS: UptimeThresholds = {
+  operational: 99,
+  degraded: 95,
+};
+
+/** Aggregate over one system's readings (system-card / status-item level). */
+export interface SystemAggregate {
+  name: string;
+  /** Readings sorted most-recent-first */
+  readingsDesc: CompactReading[];
+  /** Most recent reading */
+  latest: CompactReading;
+  /** Percentage of readings with state 'up' (0-100, unrounded) */
+  uptimePercent: number;
+  /** uptimePercent formatted as e.g. "99.98%" */
+  uptimeFormatted: string;
+  /** Average latency over successful (up, 2xx) readings; undefined if none */
+  avgResponseTime: number | undefined;
+}
+
+/** Aggregate over one day's readings for one service (uptime-bar level). */
+export interface DayAggregate {
+  date: string;
+  checksTotal: number;
+  /** Checks with state 'up' or 'maintenance' */
+  checksPassed: number;
+  /** checksPassed / checksTotal, 0 when no checks (fraction 0-1) */
+  uptimeFraction: number;
+  /** Average latency over 'up' readings, rounded; null if none */
+  avgLatencyMs: number | null;
+  /** P95 latency over 'up' readings; null if none */
+  p95LatencyMs: number | null;
+  /** Count of up→down transitions in reading order */
+  incidentCount: number;
+  status: DayLevelStatus;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,8 +43,11 @@ export interface SystemAggregate {
   name: string;
   /** Readings sorted most-recent-first */
   readingsDesc: CompactReading[];
-  /** Most recent reading */
-  latest: CompactReading;
+  /**
+   * Most recent reading.  `undefined` when `readingsDesc` is empty (i.e.
+   * `aggregateSystem` was called with an empty `readings` array).
+   */
+  latest: CompactReading | undefined;
   /** Percentage of readings with state 'up' (0-100, unrounded) */
   uptimePercent: number;
   /** uptimePercent formatted as e.g. "99.98%" */

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "lib", "**/*.test.ts"]
+}

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/golden/load-content-items.golden.json
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/golden/load-content-items.golden.json
@@ -1,0 +1,114 @@
+[
+  {
+    "name": "alpha",
+    "status": "up",
+    "lastChecked": "2026-07-01T00:10:00.000Z",
+    "responseTime": 110,
+    "uptime": "100.00%",
+    "incidentCount": 0,
+    "history": [
+      {
+        "timestamp": "2026-07-01T00:10:00.000Z",
+        "status": "up",
+        "code": 200,
+        "responseTime": 120,
+        "latency": 120
+      },
+      {
+        "timestamp": "2026-07-01T00:05:00.000Z",
+        "status": "up",
+        "code": 204,
+        "responseTime": 110,
+        "latency": 110
+      },
+      {
+        "timestamp": "2026-07-01T00:00:00.000Z",
+        "status": "up",
+        "code": 200,
+        "responseTime": 100,
+        "latency": 100
+      }
+    ]
+  },
+  {
+    "name": "beta",
+    "status": "up",
+    "lastChecked": "2026-07-01T00:15:00.000Z",
+    "responseTime": 60,
+    "uptime": "75.00%",
+    "incidentCount": 0,
+    "history": [
+      {
+        "timestamp": "2026-07-01T00:15:00.000Z",
+        "status": "up",
+        "code": 200,
+        "responseTime": 70,
+        "latency": 70
+      },
+      {
+        "timestamp": "2026-07-01T00:10:00.000Z",
+        "status": "up",
+        "code": 301,
+        "responseTime": 400,
+        "latency": 400
+      },
+      {
+        "timestamp": "2026-07-01T00:05:00.000Z",
+        "status": "down",
+        "code": 500,
+        "responseTime": 0,
+        "latency": 0,
+        "error": "HTTP 500"
+      },
+      {
+        "timestamp": "2026-07-01T00:00:00.000Z",
+        "status": "up",
+        "code": 200,
+        "responseTime": 50,
+        "latency": 50
+      }
+    ]
+  },
+  {
+    "name": "gamma",
+    "status": "down",
+    "lastChecked": "2026-07-01T00:05:00.000Z",
+    "uptime": "0.00%",
+    "incidentCount": 0,
+    "history": [
+      {
+        "timestamp": "2026-07-01T00:05:00.000Z",
+        "status": "down",
+        "code": 0,
+        "responseTime": 0,
+        "latency": 0,
+        "error": "timeout"
+      },
+      {
+        "timestamp": "2026-07-01T00:00:00.000Z",
+        "status": "down",
+        "code": 503,
+        "responseTime": 0,
+        "latency": 0,
+        "error": "HTTP 503"
+      }
+    ]
+  },
+  {
+    "name": "delta",
+    "status": "up",
+    "lastChecked": "2026-07-01T00:07:00.000Z",
+    "responseTime": 33,
+    "uptime": "100.00%",
+    "incidentCount": 0,
+    "history": [
+      {
+        "timestamp": "2026-07-01T00:07:00.000Z",
+        "status": "up",
+        "code": 200,
+        "responseTime": 33,
+        "latency": 33
+      }
+    ]
+  }
+]

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/golden/post-build-systems.golden.json
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/golden/post-build-systems.golden.json
@@ -1,0 +1,105 @@
+{
+  "alpha": {
+    "name": "alpha",
+    "url": "",
+    "currentStatus": "up",
+    "lastChecked": "2026-07-01T00:10:00.000Z",
+    "history": [
+      {
+        "timestamp": "2026-07-01T00:10:00.000Z",
+        "status": "up",
+        "responseTime": 120,
+        "code": 200
+      },
+      {
+        "timestamp": "2026-07-01T00:05:00.000Z",
+        "status": "up",
+        "responseTime": 110,
+        "code": 204
+      },
+      {
+        "timestamp": "2026-07-01T00:00:00.000Z",
+        "status": "up",
+        "responseTime": 100,
+        "code": 200
+      }
+    ],
+    "uptime": "100.00%",
+    "uptimeDay": "100.00%",
+    "timeDay": 110
+  },
+  "beta": {
+    "name": "beta",
+    "url": "",
+    "currentStatus": "up",
+    "lastChecked": "2026-07-01T00:15:00.000Z",
+    "history": [
+      {
+        "timestamp": "2026-07-01T00:15:00.000Z",
+        "status": "up",
+        "responseTime": 70,
+        "code": 200
+      },
+      {
+        "timestamp": "2026-07-01T00:10:00.000Z",
+        "status": "up",
+        "responseTime": 0,
+        "code": 301
+      },
+      {
+        "timestamp": "2026-07-01T00:05:00.000Z",
+        "status": "down",
+        "responseTime": 0,
+        "code": 500
+      },
+      {
+        "timestamp": "2026-07-01T00:00:00.000Z",
+        "status": "up",
+        "responseTime": 50,
+        "code": 200
+      }
+    ],
+    "uptime": "75.00%",
+    "uptimeDay": "75.00%",
+    "timeDay": 60
+  },
+  "gamma": {
+    "name": "gamma",
+    "url": "",
+    "currentStatus": "down",
+    "lastChecked": "2026-07-01T00:05:00.000Z",
+    "history": [
+      {
+        "timestamp": "2026-07-01T00:05:00.000Z",
+        "status": "down",
+        "responseTime": 0,
+        "code": 0
+      },
+      {
+        "timestamp": "2026-07-01T00:00:00.000Z",
+        "status": "down",
+        "responseTime": 0,
+        "code": 503
+      }
+    ],
+    "uptime": "0.00%",
+    "uptimeDay": "0.00%"
+  },
+  "delta": {
+    "name": "delta",
+    "url": "",
+    "currentStatus": "up",
+    "lastChecked": "2026-07-01T00:07:00.000Z",
+    "history": [
+      {
+        "timestamp": "2026-07-01T00:07:00.000Z",
+        "status": "up",
+        "responseTime": 33,
+        "code": 200
+      }
+    ],
+    "uptime": "100.00%",
+    "uptimeDay": "100.00%",
+    "timeDay": 33
+  }
+}

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/golden/server-aggregation-golden.test.ts
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/golden/server-aggregation-golden.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Golden-file test for the server-side aggregation pipeline (ADR-005
+ * Migration Phase 0, ticket #65).
+ *
+ * The goldens under __tests__/golden/*.golden.json were captured from the
+ * PRE-refactor implementation (loadContent + postBuild at main@86dfd1b).
+ * The core extraction must reproduce them byte-for-byte: this test runs
+ * the REAL plugin (unmocked fs) against a fixture current.json in a temp
+ * site dir and compares the deterministic outputs.
+ *
+ * To regenerate (only when behavior change is INTENDED and reviewed):
+ *   UPDATE_GOLDENS=1 npx jest __tests__/golden
+ */
+
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import type {LoadContext} from '@docusaurus/types';
+import pluginStatusPage from '../../src/index';
+import type {PluginOptions} from '../../src/types';
+
+const GOLDEN_DIR = path.join(__dirname);
+const ITEMS_GOLDEN = path.join(GOLDEN_DIR, 'load-content-items.golden.json');
+const SYSTEMS_GOLDEN = path.join(GOLDEN_DIR, 'post-build-systems.golden.json');
+
+/**
+ * Deterministic fixture readings exercising the edge cases the
+ * aggregation must preserve:
+ * - alpha: all up, varying latency (plain average)
+ * - beta:  mixed up/down PLUS an 'up' reading with a non-2xx code (301),
+ *          which must be EXCLUDED from response-time averages but count
+ *          toward uptime
+ * - gamma: all down (avg undefined / omitted)
+ * - delta: single reading
+ * Timestamps are fixed and out of order to exercise the sort.
+ */
+const T0 = Date.UTC(2026, 6, 1, 0, 0, 0); // 2026-07-01T00:00:00Z
+const MIN = 60_000;
+const FIXTURE_READINGS = [
+  {t: T0 + 10 * MIN, svc: 'alpha', state: 'up', code: 200, lat: 120},
+  {t: T0 + 0 * MIN, svc: 'alpha', state: 'up', code: 200, lat: 100},
+  {t: T0 + 5 * MIN, svc: 'alpha', state: 'up', code: 204, lat: 110},
+
+  {t: T0 + 0 * MIN, svc: 'beta', state: 'up', code: 200, lat: 50},
+  {t: T0 + 5 * MIN, svc: 'beta', state: 'down', code: 500, lat: 0, err: 'HTTP 500'},
+  {t: T0 + 10 * MIN, svc: 'beta', state: 'up', code: 301, lat: 400},
+  {t: T0 + 15 * MIN, svc: 'beta', state: 'up', code: 200, lat: 70},
+
+  {t: T0 + 0 * MIN, svc: 'gamma', state: 'down', code: 503, lat: 0, err: 'HTTP 503'},
+  {t: T0 + 5 * MIN, svc: 'gamma', state: 'down', code: 0, lat: 0, err: 'timeout'},
+
+  {t: T0 + 7 * MIN, svc: 'delta', state: 'up', code: 200, lat: 33},
+];
+
+const ENTITIES = [
+  {name: 'alpha', type: 'system' as const},
+  {name: 'beta', type: 'system' as const},
+  {name: 'gamma', type: 'system' as const},
+  {name: 'delta', type: 'system' as const},
+];
+
+async function runPipeline(): Promise<{items: unknown; systems: Record<string, unknown>}> {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'stentorosaur-golden-'));
+  try {
+    const siteDir = path.join(tmp, 'site');
+    const outDir = path.join(tmp, 'build');
+    const generatedFilesDir = path.join(siteDir, '.docusaurus');
+    await fs.ensureDir(path.join(siteDir, 'status-data'));
+    await fs.writeJson(path.join(siteDir, 'status-data', 'current.json'), FIXTURE_READINGS);
+
+    const context = {
+      siteDir,
+      generatedFilesDir,
+      outDir,
+      baseUrl: '/',
+      siteConfig: {baseUrl: '/'} as any,
+    } as LoadContext;
+
+    const options: PluginOptions = {
+      owner: 'golden-owner',
+      repo: 'golden-repo',
+      entities: ENTITIES,
+      useDemoData: false,
+      showServices: true,
+      showIncidents: true,
+    };
+
+    const plugin = await pluginStatusPage(context, options);
+    const content = await plugin.loadContent!();
+    await (plugin as any).postBuild({outDir});
+
+    const systems: Record<string, unknown> = {};
+    for (const entity of ENTITIES) {
+      systems[entity.name] = await fs.readJson(
+        path.join(outDir, 'status-data', 'systems', `${entity.name}.json`)
+      );
+    }
+    return {items: content.items, systems};
+  } finally {
+    await fs.remove(tmp);
+  }
+}
+
+describe('server aggregation golden (pre-refactor behavior pinned)', () => {
+  jest.setTimeout(30_000);
+
+  it('loadContent items and postBuild system files match the goldens', async () => {
+    const {items, systems} = await runPipeline();
+
+    if (process.env.UPDATE_GOLDENS) {
+      await fs.writeJson(ITEMS_GOLDEN, items, {spaces: 2});
+      await fs.writeJson(SYSTEMS_GOLDEN, systems, {spaces: 2});
+      // eslint-disable-next-line no-console
+      console.warn('[golden] goldens rewritten — review the diff carefully');
+      return;
+    }
+
+    expect(fs.existsSync(ITEMS_GOLDEN)).toBe(true);
+    expect(fs.existsSync(SYSTEMS_GOLDEN)).toBe(true);
+    // Byte-level comparison via canonical JSON stringification
+    expect(JSON.stringify(items, null, 2)).toBe(
+      JSON.stringify(await fs.readJson(ITEMS_GOLDEN), null, 2)
+    );
+    expect(JSON.stringify(systems, null, 2)).toBe(
+      JSON.stringify(await fs.readJson(SYSTEMS_GOLDEN), null, 2)
+    );
+  });
+});

--- a/packages/docusaurus-plugin-stentorosaur/jest.config.js
+++ b/packages/docusaurus-plugin-stentorosaur/jest.config.js
@@ -38,6 +38,8 @@ module.exports = {
     }],
   },
   moduleNameMapper: {
+    // Resolve the workspace-sibling core package from source (no build needed in tests)
+    '^@stentorosaur/core$': '<rootDir>/../core/src',
     // Mock CSS modules
     '\\.css$': '<rootDir>/__mocks__/styleMock.js',
     // Mock @theme modules

--- a/packages/docusaurus-plugin-stentorosaur/package.json
+++ b/packages/docusaurus-plugin-stentorosaur/package.json
@@ -54,6 +54,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@stentorosaur/core": "^0.1.0",
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/types": "^3.0.0",
     "@docusaurus/utils": "^3.0.0",

--- a/packages/docusaurus-plugin-stentorosaur/src/context/StatusDataProvider.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/context/StatusDataProvider.tsx
@@ -23,19 +23,18 @@ import React, {
   useMemo,
   type ReactNode,
 } from 'react';
+import {
+  aggregateDayReadings,
+  calculateStatusFromUptime,
+  groupReadingsByDate,
+} from '@stentorosaur/core';
+import type { CompactReading } from '@stentorosaur/core';
 import type { DailySummaryFile, DailySummaryEntry } from '../types';
 
 /**
- * Compact reading format from current.json
+ * Compact reading format from current.json (shared core type, ADR-005)
  */
-interface CurrentReading {
-  t: number;
-  svc: string;
-  state: 'up' | 'down' | 'degraded' | 'maintenance';
-  code: number;
-  lat: number;
-  err?: string;
-}
+type CurrentReading = CompactReading;
 
 /**
  * Current status file structure
@@ -103,106 +102,28 @@ const StatusDataContext = createContext<StatusDataContextValue | undefined>(
 );
 
 /**
- * Uptime thresholds for status calculation (from ADR-004)
- */
-const THRESHOLDS = {
-  OPERATIONAL: 99, // >= 99% = operational
-  DEGRADED: 95, // >= 95% = degraded, < 95% = outage
-};
-
-/**
  * Stale data threshold (24 hours in milliseconds)
  */
 const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Calculate status from uptime percentage
- */
-function calculateStatus(
-  uptimePercent: number,
-  checksTotal: number
-): DayStatus['status'] {
-  if (checksTotal === 0) return 'no-data';
-  if (uptimePercent >= THRESHOLDS.OPERATIONAL) return 'operational';
-  if (uptimePercent >= THRESHOLDS.DEGRADED) return 'degraded';
-  return 'outage';
-}
-
-/**
- * Calculate p95 latency from an array of latency values
- */
-function calculateP95(latencies: number[]): number | null {
-  if (latencies.length === 0) return null;
-  const sorted = [...latencies].sort((a, b) => a - b);
-  const index = Math.ceil(sorted.length * 0.95) - 1;
-  return sorted[Math.max(0, index)];
-}
-
-/**
- * Group readings by date for a specific service
- */
-function groupReadingsByDate(
-  readings: CurrentReading[],
-  serviceName: string
-): Map<string, CurrentReading[]> {
-  const groups = new Map<string, CurrentReading[]>();
-  const lowerServiceName = serviceName.toLowerCase();
-
-  for (const reading of readings) {
-    if (reading.svc.toLowerCase() !== lowerServiceName) continue;
-
-    const date = new Date(reading.t).toISOString().split('T')[0];
-    if (!groups.has(date)) {
-      groups.set(date, []);
-    }
-    groups.get(date)!.push(reading);
-  }
-
-  return groups;
-}
-
-/**
  * Aggregate readings for a specific day into a DayStatus
+ * (math lives in @stentorosaur/core, ADR-005)
  */
-function aggregateDayReadings(
+function dayReadingsToDayStatus(
   date: string,
   readings: CurrentReading[]
 ): DayStatus {
-  const checksTotal = readings.length;
-  const checksPassed = readings.filter(
-    (r) => r.state === 'up' || r.state === 'maintenance'
-  ).length;
-  const uptimePercent =
-    checksTotal > 0 ? (checksPassed / checksTotal) * 100 : 0;
-
-  const latencies = readings.filter((r) => r.state === 'up').map((r) => r.lat);
-
-  const avgLatencyMs =
-    latencies.length > 0
-      ? Math.round(
-          latencies.reduce((sum, lat) => sum + lat, 0) / latencies.length
-        )
-      : null;
-
-  const p95LatencyMs = calculateP95(latencies);
-
-  // Count incidents (transitions from up to down)
-  let incidentCount = 0;
-  for (let i = 1; i < readings.length; i++) {
-    if (readings[i - 1].state === 'up' && readings[i].state === 'down') {
-      incidentCount++;
-    }
-  }
-
+  const day = aggregateDayReadings(date, readings);
   return {
-    date,
-    uptimePercent,
-    incidents: incidentCount,
-    checksTotal,
-    checksPassed,
-    status: calculateStatus(uptimePercent, checksTotal),
-    avgLatencyMs,
-    p95LatencyMs,
+    date: day.date,
+    uptimePercent: day.uptimeFraction * 100,
+    incidents: day.incidentCount,
+    checksTotal: day.checksTotal,
+    checksPassed: day.checksPassed,
+    status: day.status,
+    avgLatencyMs: day.avgLatencyMs,
+    p95LatencyMs: day.p95LatencyMs,
   };
 }
 
@@ -217,7 +138,7 @@ function summaryEntryToDayStatus(entry: DailySummaryEntry): DayStatus {
     incidents: entry.incidentCount,
     checksTotal: entry.checksTotal,
     checksPassed: entry.checksPassed,
-    status: calculateStatus(uptimePercent, entry.checksTotal),
+    status: calculateStatusFromUptime(uptimePercent, entry.checksTotal),
     avgLatencyMs: entry.avgLatencyMs,
     p95LatencyMs: entry.p95LatencyMs,
   };
@@ -376,7 +297,7 @@ export function StatusDataProvider({
       if (todayReadings.length > 0) {
         // Sort by timestamp for accurate incident counting
         todayReadings.sort((a, b) => a.t - b.t);
-        entries.push(aggregateDayReadings(today, todayReadings));
+        entries.push(dayReadingsToDayStatus(today, todayReadings));
       }
 
       // Add historical entries (filter out today if it exists in summary)

--- a/packages/docusaurus-plugin-stentorosaur/src/hooks/useDailySummary.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/hooks/useDailySummary.ts
@@ -17,19 +17,17 @@
  */
 
 import { useState, useEffect, useMemo } from 'react';
+import {
+  aggregateDayReadings as coreAggregateDayReadings,
+  groupReadingsByDate,
+} from '@stentorosaur/core';
+import type { CompactReading } from '@stentorosaur/core';
 import type { DailySummaryFile, DailySummaryEntry } from '../types';
 
 /**
- * Compact reading format from current.json
+ * Compact reading format from current.json (shared core type, ADR-005)
  */
-interface CurrentReading {
-  t: number;
-  svc: string;
-  state: 'up' | 'down' | 'degraded' | 'maintenance';
-  code: number;
-  lat: number;
-  err?: string;
-}
+type CurrentReading = CompactReading;
 
 /**
  * Options for useDailySummary hook
@@ -60,73 +58,20 @@ export interface UseDailySummaryResult {
 }
 
 /**
- * Calculate p95 latency from an array of latency values
- */
-function calculateP95(latencies: number[]): number | null {
-  if (latencies.length === 0) return null;
-  const sorted = [...latencies].sort((a, b) => a - b);
-  const index = Math.ceil(sorted.length * 0.95) - 1;
-  return sorted[Math.max(0, index)];
-}
-
-/**
  * Aggregate readings for a specific day into a DailySummaryEntry
+ * (math lives in @stentorosaur/core, ADR-005)
  */
 function aggregateDayReadings(date: string, readings: CurrentReading[]): DailySummaryEntry {
-  const checksTotal = readings.length;
-  const checksPassed = readings.filter(r => r.state === 'up' || r.state === 'maintenance').length;
-  const uptimePct = checksTotal > 0 ? checksPassed / checksTotal : 0;
-
-  const latencies = readings
-    .filter(r => r.state === 'up')
-    .map(r => r.lat);
-
-  const avgLatencyMs = latencies.length > 0
-    ? Math.round(latencies.reduce((sum, lat) => sum + lat, 0) / latencies.length)
-    : null;
-
-  const p95LatencyMs = calculateP95(latencies);
-
-  // Count incidents (transitions from up to down)
-  let incidentCount = 0;
-  for (let i = 1; i < readings.length; i++) {
-    if (readings[i - 1].state === 'up' && readings[i].state === 'down') {
-      incidentCount++;
-    }
-  }
-
+  const day = coreAggregateDayReadings(date, readings);
   return {
-    date,
-    uptimePct,
-    avgLatencyMs,
-    p95LatencyMs,
-    checksTotal,
-    checksPassed,
-    incidentCount,
+    date: day.date,
+    uptimePct: day.uptimeFraction,
+    avgLatencyMs: day.avgLatencyMs,
+    p95LatencyMs: day.p95LatencyMs,
+    checksTotal: day.checksTotal,
+    checksPassed: day.checksPassed,
+    incidentCount: day.incidentCount,
   };
-}
-
-/**
- * Group readings by date (for aggregating current.json)
- */
-function groupReadingsByDate(
-  readings: CurrentReading[],
-  serviceName: string
-): Map<string, CurrentReading[]> {
-  const groups = new Map<string, CurrentReading[]>();
-  const lowerServiceName = serviceName.toLowerCase();
-
-  for (const reading of readings) {
-    if (reading.svc.toLowerCase() !== lowerServiceName) continue;
-
-    const date = new Date(reading.t).toISOString().split('T')[0];
-    if (!groups.has(date)) {
-      groups.set(date, []);
-    }
-    groups.get(date)!.push(reading);
-  }
-
-  return groups;
 }
 
 /**

--- a/packages/docusaurus-plugin-stentorosaur/src/index.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/index.ts
@@ -271,6 +271,9 @@ function convertReadingsToSystemFiles(readings: CompactReading[]): SystemStatusF
 
   for (const [systemName, systemReadings] of groupReadingsBySystem(readings)) {
     const agg = aggregateSystem(systemName, systemReadings);
+    // groupReadingsBySystem only creates entries when a reading exists, so
+    // agg.latest is always defined here.  The guard keeps TypeScript happy.
+    if (!agg.latest) continue;
 
     // Convert to StatusCheckHistory format (non-successful checks report 0ms)
     const history = agg.readingsDesc.map(r => ({
@@ -449,6 +452,9 @@ export default async function pluginStatus(
               }
 
               const agg = aggregateSystem(systemName, readings);
+              // groupReadingsBySystem only creates entries when a reading
+              // exists, so agg.latest is always defined here.
+              if (!agg.latest) continue;
 
               items.push({
                 name: systemName,

--- a/packages/docusaurus-plugin-stentorosaur/src/index.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/index.ts
@@ -8,6 +8,12 @@
 import path from 'path';
 import fs from 'fs-extra';
 import {normalizeUrl} from '@docusaurus/utils';
+import {
+  aggregateSystem,
+  averageRecentResponseTime,
+  groupReadingsBySystem,
+} from '@stentorosaur/core';
+import type {CompactReading} from '@stentorosaur/core';
 import type {LoadContext, Plugin} from '@docusaurus/types';
 import type {PluginOptions, StatusData, StatusItem, SystemStatusFile, StatusIncident, ScheduledMaintenance, Entity} from './types';
 import {GitHubStatusService} from './github-service';
@@ -229,15 +235,12 @@ async function readSystemFiles(systemsDir: string): Promise<Partial<StatusItem>[
         
         // Calculate average response time from recent history (fallback if timeDay not set)
         let avgResponseTime: number | undefined;
-        
+
         // Prefer calculated time-window averages
         if (data.timeDay !== undefined && data.timeDay > 0) {
           avgResponseTime = data.timeDay;
         } else if (data.history && data.history.length > 0) {
-          // Fallback: calculate from recent history
-          const recentChecks = data.history.slice(0, 10); // Last 10 checks
-          const sum = recentChecks.reduce((acc, check) => acc + check.responseTime, 0);
-          avgResponseTime = Math.round(sum / recentChecks.length);
+          avgResponseTime = averageRecentResponseTime(data.history);
         }
         
         systemData.push({
@@ -263,54 +266,32 @@ async function readSystemFiles(systemsDir: string): Promise<Partial<StatusItem>[
 /**
  * Convert compact readings from current.json to SystemStatusFile format
  */
-function convertReadingsToSystemFiles(readings: any[]): SystemStatusFile[] {
-  // Group readings by system
-  const systemMap = new Map<string, any[]>();
-  for (const reading of readings) {
-    if (!systemMap.has(reading.svc)) {
-      systemMap.set(reading.svc, []);
-    }
-    systemMap.get(reading.svc)!.push(reading);
-  }
-  
+function convertReadingsToSystemFiles(readings: CompactReading[]): SystemStatusFile[] {
   const systemFiles: SystemStatusFile[] = [];
-  
-  for (const [systemName, systemReadings] of systemMap.entries()) {
-    // Sort by timestamp (most recent first)
-    systemReadings.sort((a, b) => b.t - a.t);
-    
-    const latest = systemReadings[0];
-    
-    // Convert to StatusCheckHistory format
-    const history = systemReadings.map(r => ({
+
+  for (const [systemName, systemReadings] of groupReadingsBySystem(readings)) {
+    const agg = aggregateSystem(systemName, systemReadings);
+
+    // Convert to StatusCheckHistory format (non-successful checks report 0ms)
+    const history = agg.readingsDesc.map(r => ({
       timestamp: new Date(r.t).toISOString(),
       status: r.state,
       responseTime: r.state === 'up' && r.code >= 200 && r.code < 300 ? r.lat : 0,
       code: r.code,
     }));
-    
-    // Calculate uptime percentage
-    const upReadings = systemReadings.filter(r => r.state === 'up').length;
-    const uptime = systemReadings.length > 0 ? (upReadings / systemReadings.length) * 100 : 0;
-    
-    // Calculate average response time from successful readings only
-    const successfulReadings = systemReadings.filter(r => r.state === 'up' && r.code >= 200 && r.code < 300);
-    const avgResponseTime = successfulReadings.length > 0
-      ? Math.round(successfulReadings.reduce((sum: number, r: any) => sum + r.lat, 0) / successfulReadings.length)
-      : undefined;
-    
+
     systemFiles.push({
       name: systemName,
       url: '', // URL not stored in compact format
-      currentStatus: latest.state,
-      lastChecked: new Date(latest.t).toISOString(),
+      currentStatus: agg.latest.state,
+      lastChecked: new Date(agg.latest.t).toISOString(),
       history,
-      uptime: `${(Math.round(uptime * 100) / 100).toFixed(2)}%`,
-      uptimeDay: `${(Math.round(uptime * 100) / 100).toFixed(2)}%`,
-      timeDay: avgResponseTime,
+      uptime: agg.uptimeFormatted,
+      uptimeDay: agg.uptimeFormatted,
+      timeDay: agg.avgResponseTime,
     });
   }
-  
+
   return systemFiles;
 }
 
@@ -453,51 +434,30 @@ export default async function pluginStatus(
               `[docusaurus-plugin-stentorosaur] Found current.json with ${currentData.length} readings, aggregating...`
             );
             
-            // Group readings by system
-            const systemMap = new Map<string, any[]>();
-            for (const reading of currentData) {
-              if (!systemMap.has(reading.svc)) {
-                systemMap.set(reading.svc, []);
-              }
-              systemMap.get(reading.svc)!.push(reading);
-            }
-            
-            // Calculate stats for each system
             // Filter to only include systems that are in the entities configuration (Issue #62)
             const configuredSystemNames = new Set(
               entities.map(e => e.name.toLowerCase())
             );
 
             items = [];
-            for (const [systemName, readings] of systemMap.entries()) {
+            for (const [systemName, readings] of groupReadingsBySystem(
+              currentData as CompactReading[]
+            )) {
               // Skip systems not in the entities configuration
               if (configuredSystemNames.size > 0 && !configuredSystemNames.has(systemName.toLowerCase())) {
                 continue;
               }
 
-              // Sort by timestamp (most recent first)
-              readings.sort((a, b) => b.t - a.t);
-              
-              const latest = readings[0];
-              
-              // Calculate uptime (percentage of 'up' readings)
-              const upReadings = readings.filter(r => r.state === 'up').length;
-              const uptime = readings.length > 0 ? (upReadings / readings.length) * 100 : 0;
-              
-              // Calculate average response time (ONLY from successful 'up' readings)
-              const successfulReadings = readings.filter(r => r.state === 'up' && r.code >= 200 && r.code < 300);
-              const avgResponseTime = successfulReadings.length > 0
-                ? Math.round(successfulReadings.reduce((sum: number, r: any) => sum + r.lat, 0) / successfulReadings.length)
-                : undefined;
-              
+              const agg = aggregateSystem(systemName, readings);
+
               items.push({
                 name: systemName,
-                status: latest.state,
-                lastChecked: new Date(latest.t).toISOString(),
-                responseTime: avgResponseTime,
-                uptime: `${(Math.round(uptime * 100) / 100).toFixed(2)}%`,
+                status: agg.latest.state,
+                lastChecked: new Date(agg.latest.t).toISOString(),
+                responseTime: agg.avgResponseTime,
+                uptime: agg.uptimeFormatted,
                 incidentCount: 0,
-                history: readings.map(r => ({
+                history: agg.readingsDesc.map(r => ({
                   timestamp: new Date(r.t).toISOString(),
                   status: r.state,
                   code: r.code,


### PR DESCRIPTION
Closes #65

Part of epic #63 (ADR-005), Phase 1 — safety net (v0.22).

## Changes

- **@stentorosaur/core** becomes real: `CompactReading` types + pure aggregation (`groupReadingsBySystem`, `aggregateSystem`, uptime/avg/format, `calculateP95`, `countIncidentTransitions`, `aggregateDayReadings`, `groupReadingsByDate`, ADR-004 thresholds). Zero runtime deps, no I/O. 23 unit tests.
- **Four call sites now import from core** (previously 3–4 hand-copies of the same math, incl. triplicated `calculateP95`): `loadContent()`, `convertReadingsToSystemFiles()`, `readSystemFiles()` fallback, and client-side `StatusDataProvider` + `useDailySummary`.
- **Golden-file tests** (captured from main@86dfd1b BEFORE the refactor, committed separately at 1e18654 for provenance): real-fs pipeline run over a fixture `current.json` covering mixed states, non-2xx 'up' readings excluded from averages, out-of-order timestamps. Post-refactor outputs are byte-identical.
- **CI**: build now precedes typecheck (plugin resolves core via workspace symlink to its `lib/`). Codecov note from PR #78 still open — core coverage wiring deferred.
- **Publish**: core publishes before the plugin, so a failed core publish can never leave the plugin on npm with an unresolvable dependency.

## Release prerequisite (human action before tagging v0.22)

`@stentorosaur/core` must be publishable: the npm **stentorosaur** org needs to exist with trusted publishing configured for this repo (same OIDC setup as the plugin). Until then, do not tag a release — the publish workflow will fail loudly at the core step (by design). Alternative if the org is unavailable: rename to `@amiable-dev/stentorosaur-core` (one-line changes in both package.jsons + imports).

## Notes

- `test-status-site` local dev: `npm install` from the workspace root now also links core (its `prepare` builds `lib/`).
- `historical-data.ts` and `scripts/bootstrap-summary.js` intentionally NOT moved — they relocate with the status/v1 schema work (#67/#68) per ticket scope.

## Test plan

- 23 new core unit tests (hand-computed edges: non-2xx exclusion, maintenance-counts-as-passed, nearest-rank p95, transition counting)
- Golden byte-identity test green post-refactor
- Full suite: 41 plugin suites / 733 tests + typecheck + workspace build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)