### PR TITLE
feat: status/v1 data contract — zod schemas, versioning, compact day encoding

### DIFF
--- a/fixtures/site/package.json
+++ b/fixtures/site/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Fixture Docusaurus site for the ADR-005 pipeline e2e harness (ticket #66). Never published.",
   "scripts": {
-    "build": "docusaurus build"
+    "build:site": "docusaurus build"
   },
   "dependencies": {
     "@amiable-dev/docusaurus-plugin-stentorosaur": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26109,6 +26109,9 @@
       "name": "@stentorosaur/core",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "zod": "^4.1.12"
+      },
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0",

--- a/packages/core/__tests__/schema-roundtrip.test.ts
+++ b/packages/core/__tests__/schema-roundtrip.test.ts
@@ -1,0 +1,241 @@
+/**
+ * status/v1 data-contract tests (ADR-005 §2; epic #63 ticket #67).
+ *
+ * Every writer output must parse under the reader schema (round-trip),
+ * unknown major versions must be rejected with actionable errors, and
+ * the summary fixture must stay within the ADR's size target (~2–10 KB
+ * for a five-entity site).
+ */
+
+import {
+  STATUS_SCHEMA_VERSION,
+  decodeDayRollups,
+  encodeDayRollups,
+  parseEntityDetail,
+  parseRawIncidentBody,
+  parseSummary,
+  summarySchema,
+} from '../src/status-v1';
+import type {DayRollup, StatusSummary} from '../src/status-v1';
+
+/**
+ * A representative five-entity summary, exercising every branch.
+ * Days use the COMPACT tuple encoding ([uptime, avgMs, worstChar]) with a
+ * daysEnd anchor — the verbose per-day object form blew the ADR's 2-10 KB
+ * summary budget (~29 KB for 5x90 objects vs ~7 KB for tuples).
+ */
+function buildFixtureSummary(): StatusSummary {
+  const days = (uptime: number, avgMs: number | null) =>
+    Array.from({length: 90}, () =>
+      [uptime, avgMs, uptime === 100 ? 'u' : 'd'] as [number, number | null, 'u' | 'd']
+    );
+  const daysEnd = '2026-07-12';
+
+  return {
+    schemaVersion: STATUS_SCHEMA_VERSION,
+    generatedAt: '2026-07-12T18:00:00.000Z',
+    generatedBy: 'probe@0.1.0',
+    entities: [
+      {
+        name: 'api',
+        type: 'system',
+        displayName: 'API',
+        status: 'up',
+        uptime: {d1: 100, d7: 99.98, d90: 99.95},
+        responseTimeMs: {d1: 182},
+        daysEnd,
+        days: days(100, 180),
+      },
+      {
+        name: 'web',
+        type: 'system',
+        status: 'degraded',
+        uptime: {d1: 97.5, d7: 99.1, d90: 99.7},
+        responseTimeMs: {d1: 450},
+        daysEnd,
+        days: days(97.5, 440),
+      },
+      {
+        name: 'database',
+        type: 'system',
+        status: 'down',
+        uptime: {d1: 42, d7: 90.2, d90: 98.8},
+        responseTimeMs: {d1: null},
+        daysEnd,
+        days: days(42, null),
+      },
+      {
+        name: 'onboarding',
+        type: 'process',
+        status: 'up',
+        uptime: {d1: 100, d7: 100, d90: 100},
+        responseTimeMs: {d1: null},
+        daysEnd,
+        days: days(100, null),
+      },
+      {
+        name: 'cdn',
+        type: 'system',
+        status: 'maintenance',
+        uptime: {d1: 99.9, d7: 99.9, d90: 99.9},
+        responseTimeMs: {d1: 25},
+        daysEnd,
+        days: days(99.9, 25),
+      },
+    ],
+    incidents: {
+      open: [
+        {
+          issueNumber: 101,
+          title: 'Database outage',
+          severity: 'critical',
+          status: 'open',
+          entities: ['database'],
+          createdAt: '2026-07-12T17:00:00.000Z',
+          closedAt: null,
+          bodyHtml: '<p>Investigating elevated error rates.</p>',
+        },
+      ],
+      recent: [
+        {
+          issueNumber: 97,
+          title: 'Web slowdown',
+          severity: 'minor',
+          status: 'resolved',
+          entities: ['web'],
+          createdAt: '2026-07-10T09:00:00.000Z',
+          closedAt: '2026-07-10T11:30:00.000Z',
+          bodyHtml: '<p>Resolved after cache flush.</p>',
+        },
+      ],
+    },
+    maintenance: {
+      upcoming: [
+        {
+          issueNumber: 102,
+          title: 'DB migration',
+          start: '2026-07-14T02:00:00.000Z',
+          end: '2026-07-14T04:00:00.000Z',
+          status: 'upcoming',
+          entities: ['database', 'api'],
+          bodyHtml: '<p>Read-only mode during migration.</p>',
+        },
+      ],
+      inProgress: [],
+    },
+  };
+}
+
+describe('summary round-trip', () => {
+  it('writer output parses under the reader schema and is stable', () => {
+    const summary = buildFixtureSummary();
+    const json = JSON.stringify(summary);
+    const parsed = parseSummary(JSON.parse(json));
+    expect(parsed).toEqual(summary);
+    // Round-trip twice: parse(stringify(parse(x))) === parse(x)
+    expect(parseSummary(JSON.parse(JSON.stringify(parsed)))).toEqual(parsed);
+  });
+
+  it('five-entity fixture stays within the ADR size target (~2-10 KB)', () => {
+    const bytes = Buffer.byteLength(JSON.stringify(buildFixtureSummary()));
+    expect(bytes).toBeGreaterThan(2_000);
+    expect(bytes).toBeLessThan(10_000); // ADR-005 §2 target, compact day tuples
+  });
+
+  it('strips nothing silently: schema is strict about entity status values', () => {
+    const bad = buildFixtureSummary() as any;
+    bad.entities[0].status = 'exploded';
+    expect(() => parseSummary(bad)).toThrow(/status/);
+  });
+
+  it('rejects a missing schemaVersion with an actionable error', () => {
+    const {schemaVersion: _drop, ...rest} = buildFixtureSummary() as any;
+    expect(() => parseSummary(rest)).toThrow(/schemaVersion/);
+  });
+
+  it('rejects an unknown FUTURE major version with an actionable error', () => {
+    const future = {...buildFixtureSummary(), schemaVersion: 2};
+    expect(() => parseSummary(future)).toThrow(
+      /schemaVersion 2.*supports.*1|unsupported.*schemaVersion/i
+    );
+  });
+});
+
+describe('entity detail round-trip', () => {
+  it('parses readings produced in the compact format', () => {
+    const detail = {
+      schemaVersion: STATUS_SCHEMA_VERSION,
+      generatedAt: '2026-07-12T18:00:00.000Z',
+      name: 'api',
+      readings: [
+        {t: 1783000000000, svc: 'api', state: 'up', code: 200, lat: 123},
+        {t: 1783000300000, svc: 'api', state: 'down', code: 500, lat: 0, err: 'HTTP 500'},
+      ],
+    };
+    const parsed = parseEntityDetail(JSON.parse(JSON.stringify(detail)));
+    expect(parsed).toEqual(detail);
+  });
+
+  it('rejects readings with unknown states', () => {
+    const detail = {
+      schemaVersion: STATUS_SCHEMA_VERSION,
+      generatedAt: '2026-07-12T18:00:00.000Z',
+      name: 'api',
+      readings: [{t: 1, svc: 'api', state: 'sideways', code: 200, lat: 1}],
+    };
+    expect(() => parseEntityDetail(detail)).toThrow();
+  });
+});
+
+describe('raw provenance entries (sanitizer re-render source, ADR-005 §7)', () => {
+  it('round-trips an issue markdown body', () => {
+    const raw = {
+      schemaVersion: STATUS_SCHEMA_VERSION,
+      issueNumber: 101,
+      updatedAt: '2026-07-12T17:05:00.000Z',
+      bodyMarkdown: '## Outage\n\nRaw **markdown**, never the only copy.',
+    };
+    expect(parseRawIncidentBody(JSON.parse(JSON.stringify(raw)))).toEqual(raw);
+  });
+});
+
+describe('day rollup encode/decode', () => {
+  it('round-trips through the compact wire form', () => {
+    const rollups: DayRollup[] = [
+      {date: '2026-07-10', uptime: 100, avgMs: 120, worst: 'up'},
+      {date: '2026-07-11', uptime: 97.2, avgMs: 300, worst: 'degraded'},
+      {date: '2026-07-12', uptime: 40, avgMs: null, worst: 'down'},
+    ];
+    const encoded = encodeDayRollups(rollups);
+    expect(encoded.daysEnd).toBe('2026-07-12');
+    expect(encoded.days).toEqual([
+      [100, 120, 'u'],
+      [97.2, 300, 'g'],
+      [40, null, 'd'],
+    ]);
+    expect(decodeDayRollups(encoded)).toEqual(rollups);
+  });
+
+  it('decode reconstructs dates backward across month boundaries', () => {
+    const decoded = decodeDayRollups({
+      daysEnd: '2026-07-01',
+      days: [
+        [100, 1, 'u'],
+        [100, 1, 'u'],
+        [100, 1, 'm'],
+      ],
+    });
+    expect(decoded.map(d => d.date)).toEqual(['2026-06-29', '2026-06-30', '2026-07-01']);
+    expect(decoded[2].worst).toBe('maintenance');
+  });
+
+  it('encode rejects empty input', () => {
+    expect(() => encodeDayRollups([])).toThrow(/at least one day/);
+  });
+});
+
+describe('schema exports', () => {
+  it('exposes the zod schema for composition by probe/plugin', () => {
+    expect(summarySchema.safeParse(buildFixtureSummary()).success).toBe(true);
+  });
+});

--- a/packages/core/__tests__/schema-roundtrip.test.ts
+++ b/packages/core/__tests__/schema-roundtrip.test.ts
@@ -148,6 +148,12 @@ describe('summary round-trip', () => {
     expect(() => parseSummary(bad)).toThrow(/status/);
   });
 
+  it('rejects a semantically invalid daysEnd (e.g. month 13)', () => {
+    const bad = buildFixtureSummary() as any;
+    bad.entities[0].daysEnd = '2026-13-45';
+    expect(() => parseSummary(bad)).toThrow();
+  });
+
   it('rejects a missing schemaVersion with an actionable error', () => {
     const {schemaVersion: _drop, ...rest} = buildFixtureSummary() as any;
     expect(() => parseSummary(rest)).toThrow(/schemaVersion/);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,5 +30,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "zod": "^4.1.12"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,4 @@
 
 export * from './types';
 export * from './aggregate';
+export * from './status-v1';

--- a/packages/core/src/status-v1.ts
+++ b/packages/core/src/status-v1.ts
@@ -23,7 +23,12 @@ export const entityStateSchema = z.enum(['up', 'degraded', 'down', 'maintenance'
 const isoDateTime = z.string().refine(s => !Number.isNaN(Date.parse(s)), {
   message: 'must be an ISO 8601 datetime',
 });
-const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD');
+const isoDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD')
+  .refine(s => !Number.isNaN(Date.parse(`${s}T00:00:00Z`)), {
+    message: 'must be a valid calendar date',
+  });
 
 /**
  * One-character worst-state codes for the compact day encoding.

--- a/packages/core/src/status-v1.ts
+++ b/packages/core/src/status-v1.ts
@@ -1,0 +1,223 @@
+/**
+ * status/v1 — the single canonical data contract (ADR-005 §2).
+ *
+ * Everything the data branch serves is validated against these schemas on
+ * write AND read. `schemaVersion` gates major migrations: minor additive
+ * fields are tolerated (unknown keys are stripped, never fatal), while an
+ * unknown major version fails loudly with an actionable message.
+ *
+ * File layout on the data branch:
+ *   status/v1/summary.json          — parseSummary (the client's one fetch)
+ *   status/v1/entities/<name>.json  — parseEntityDetail (on card expand)
+ *   status/v1/raw/<issue>.json      — parseRawIncidentBody (provenance for
+ *                                     re-rendering after sanitizer CVEs, §7)
+ */
+
+import {z} from 'zod';
+
+export const STATUS_SCHEMA_VERSION = 1;
+
+/** Entity/reading state — matches CompactReading.state. */
+export const entityStateSchema = z.enum(['up', 'degraded', 'down', 'maintenance']);
+
+const isoDateTime = z.string().refine(s => !Number.isNaN(Date.parse(s)), {
+  message: 'must be an ISO 8601 datetime',
+});
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD');
+
+/**
+ * One-character worst-state codes for the compact day encoding.
+ * The verbose object form (`{date, uptime, avgMs, worst}` × 90 × N
+ * entities) measured ~29 KB for five entities — triple the ADR-005 §2
+ * summary budget — so days ship as `[uptime, avgMs, worstChar]` tuples
+ * anchored by a single `daysEnd` date per entity.
+ */
+export const WORST_CODES = {u: 'up', g: 'degraded', d: 'down', m: 'maintenance'} as const;
+export type WorstCode = keyof typeof WORST_CODES;
+
+/** Compact day tuple: [uptime 0-100, avgMs|null, worst-state code]. */
+export const dayTupleSchema = z.tuple([
+  z.number().min(0).max(100),
+  z.number().nullable(),
+  z.enum(['u', 'g', 'd', 'm']),
+]);
+export type DayTuple = z.infer<typeof dayTupleSchema>;
+
+/** Decoded day rollup (ergonomic client shape — see decodeDayRollups). */
+export interface DayRollup {
+  date: string;
+  /** Uptime percentage 0-100 */
+  uptime: number;
+  /** Average latency over 'up' checks; null when none (or not probed) */
+  avgMs: number | null;
+  /** Worst state observed that day */
+  worst: (typeof WORST_CODES)[WorstCode];
+}
+
+export const summaryEntitySchema = z.object({
+  name: z.string().min(1),
+  type: z.enum(['system', 'process']),
+  displayName: z.string().optional(),
+  status: entityStateSchema,
+  uptime: z.object({
+    d1: z.number().min(0).max(100),
+    d7: z.number().min(0).max(100),
+    d90: z.number().min(0).max(100),
+  }),
+  responseTimeMs: z.object({
+    d1: z.number().nullable(),
+  }),
+  /** UTC date (YYYY-MM-DD) of the LAST entry in days */
+  daysEnd: isoDate,
+  /** Daily rollups oldest→newest as compact tuples, at most 90 */
+  days: z.array(dayTupleSchema).max(90),
+});
+
+export const incidentSchema = z.object({
+  issueNumber: z.number().int().positive(),
+  title: z.string(),
+  severity: z.enum(['critical', 'major', 'minor']),
+  status: z.enum(['open', 'resolved']),
+  entities: z.array(z.string()),
+  createdAt: isoDateTime,
+  closedAt: isoDateTime.nullable(),
+  /** Sanitized at WRITE time (ADR-005 §2); raw markdown lives in raw/ */
+  bodyHtml: z.string(),
+});
+
+export const maintenanceWindowSchema = z.object({
+  issueNumber: z.number().int().positive(),
+  title: z.string(),
+  start: isoDateTime,
+  end: isoDateTime,
+  status: z.enum(['upcoming', 'in-progress', 'completed']),
+  entities: z.array(z.string()),
+  bodyHtml: z.string(),
+});
+
+export const summarySchema = z.object({
+  schemaVersion: z.literal(STATUS_SCHEMA_VERSION),
+  generatedAt: isoDateTime,
+  generatedBy: z.string(),
+  entities: z.array(summaryEntitySchema),
+  incidents: z.object({
+    open: z.array(incidentSchema),
+    recent: z.array(incidentSchema),
+  }),
+  maintenance: z.object({
+    upcoming: z.array(maintenanceWindowSchema),
+    inProgress: z.array(maintenanceWindowSchema),
+  }),
+});
+
+export const entityDetailSchema = z.object({
+  schemaVersion: z.literal(STATUS_SCHEMA_VERSION),
+  generatedAt: isoDateTime,
+  name: z.string().min(1),
+  readings: z.array(
+    z.object({
+      t: z.number(),
+      svc: z.string(),
+      state: entityStateSchema,
+      code: z.number(),
+      lat: z.number(),
+      err: z.string().optional(),
+    })
+  ),
+});
+
+export const rawIncidentBodySchema = z.object({
+  schemaVersion: z.literal(STATUS_SCHEMA_VERSION),
+  issueNumber: z.number().int().positive(),
+  updatedAt: isoDateTime,
+  bodyMarkdown: z.string(),
+});
+
+export type StatusSummary = z.infer<typeof summarySchema>;
+export type SummaryEntity = z.infer<typeof summaryEntitySchema>;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CODE_BY_STATE = Object.fromEntries(
+  Object.entries(WORST_CODES).map(([code, state]) => [state, code])
+) as Record<(typeof WORST_CODES)[WorstCode], WorstCode>;
+
+/**
+ * Encode decoded rollups (oldest→newest, contiguous UTC days) into the
+ * compact wire form. The writer-side counterpart of decodeDayRollups.
+ */
+export function encodeDayRollups(rollups: DayRollup[]): {
+  daysEnd: string;
+  days: DayTuple[];
+} {
+  if (rollups.length === 0) {
+    throw new Error('encodeDayRollups: at least one day is required');
+  }
+  return {
+    daysEnd: rollups[rollups.length - 1].date,
+    days: rollups.map(r => [r.uptime, r.avgMs, CODE_BY_STATE[r.worst]]),
+  };
+}
+
+/**
+ * Decode an entity's compact day tuples back into dated rollups by
+ * walking backward from daysEnd (contiguous UTC days).
+ */
+export function decodeDayRollups(
+  entity: Pick<SummaryEntity, 'daysEnd' | 'days'>
+): DayRollup[] {
+  const end = Date.parse(`${entity.daysEnd}T00:00:00Z`);
+  const count = entity.days.length;
+  return entity.days.map(([uptime, avgMs, code], i) => ({
+    date: new Date(end - (count - 1 - i) * DAY_MS).toISOString().split('T')[0],
+    uptime,
+    avgMs,
+    worst: WORST_CODES[code],
+  }));
+}
+export type StatusIncidentV1 = z.infer<typeof incidentSchema>;
+export type MaintenanceWindowV1 = z.infer<typeof maintenanceWindowSchema>;
+export type EntityDetail = z.infer<typeof entityDetailSchema>;
+export type RawIncidentBody = z.infer<typeof rawIncidentBodySchema>;
+
+/**
+ * Gate on schemaVersion BEFORE full validation so version skew produces
+ * an actionable message instead of a wall of field errors.
+ */
+function checkVersion(input: unknown, what: string): void {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error(`${what}: expected an object, got ${typeof input}`);
+  }
+  const version = (input as Record<string, unknown>).schemaVersion;
+  if (version === undefined) {
+    throw new Error(
+      `${what}: missing schemaVersion — not a status/v1 file, or produced by a pre-v1 writer. Run 'stentorosaur migrate' to convert legacy data.`
+    );
+  }
+  if (version !== STATUS_SCHEMA_VERSION) {
+    throw new Error(
+      `${what}: unsupported schemaVersion ${String(version)}; this reader supports ${STATUS_SCHEMA_VERSION}. ` +
+        `Upgrade @stentorosaur/core, or regenerate the data branch with a matching writer.`
+    );
+  }
+}
+
+function parseWith<T>(schema: z.ZodType<T>, input: unknown, what: string): T {
+  checkVersion(input, what);
+  const result = schema.safeParse(input);
+  if (!result.success) {
+    throw new Error(`${what}: invalid status/v1 payload\n${z.prettifyError(result.error)}`);
+  }
+  return result.data;
+}
+
+export function parseSummary(input: unknown): StatusSummary {
+  return parseWith(summarySchema, input, 'summary.json');
+}
+
+export function parseEntityDetail(input: unknown): EntityDetail {
+  return parseWith(entityDetailSchema, input, 'entity detail');
+}
+
+export function parseRawIncidentBody(input: unknown): RawIncidentBody {
+  return parseWith(rawIncidentBodySchema, input, 'raw incident body');
+}

--- a/packages/core/src/status-v1.ts
+++ b/packages/core/src/status-v1.ts
@@ -140,6 +140,10 @@ export const rawIncidentBodySchema = z.object({
 
 export type StatusSummary = z.infer<typeof summarySchema>;
 export type SummaryEntity = z.infer<typeof summaryEntitySchema>;
+export type StatusIncidentV1 = z.infer<typeof incidentSchema>;
+export type MaintenanceWindowV1 = z.infer<typeof maintenanceWindowSchema>;
+export type EntityDetail = z.infer<typeof entityDetailSchema>;
+export type RawIncidentBody = z.infer<typeof rawIncidentBodySchema>;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const CODE_BY_STATE = Object.fromEntries(
@@ -179,10 +183,6 @@ export function decodeDayRollups(
     worst: WORST_CODES[code],
   }));
 }
-export type StatusIncidentV1 = z.infer<typeof incidentSchema>;
-export type MaintenanceWindowV1 = z.infer<typeof maintenanceWindowSchema>;
-export type EntityDetail = z.infer<typeof entityDetailSchema>;
-export type RawIncidentBody = z.infer<typeof rawIncidentBodySchema>;
 
 /**
  * Gate on schemaVersion BEFORE full validation so version skew produces


### PR DESCRIPTION
Closes #67

Part of epic #63 (ADR-005), Phase 2 — hard cutover (v1.0). First Phase 2 ticket.

## Changes

- **`status/v1` contract in @stentorosaur/core**: `summarySchema`, `entityDetailSchema`, `rawIncidentBodySchema` (the §7 provenance shape), all gated by `schemaVersion` with parse helpers whose version-skew errors are actionable (missing → 'run stentorosaur migrate'; future major → upgrade the reader or regenerate).
- **Compact day encoding**: the ADR's illustrative per-day objects measured **~29 KB** for a 5-entity × 90-day summary — 3× the §2 budget (2–10 KB). Days now ship as `[uptime, avgMs, worstChar]` tuples anchored by one `daysEnd` date per entity (~7 KB for the same fixture), with `encodeDayRollups`/`decodeDayRollups` giving writers/readers the ergonomic dated form. This is a deliberate contract-level deviation from the ADR's sketch, made to satisfy the ADR's own stated budget; flagged here for review.
- zod (already in the tree) becomes core's only runtime dependency.
- Fixture-site build script renamed `build:site` so root `npm run build --workspaces` no longer triggers a docusaurus build (the e2e runner invokes it directly).

## Test plan (TDD: round-trip suite written first, failed on missing module)

- 12 new tests: writer→reader round-trips, double-round-trip stability, size budget (>2 KB, <10 KB enforced), enum strictness, missing/future schemaVersion rejection messages, entity-detail and raw-body round-trips, encode/decode including month-boundary date reconstruction
- Core suite 35 green; plugin 733 green; typecheck green; e2e harness 10/10 green

## Consumers

Deliberately none yet — #68 (core transforms/buildSummary) writes this shape; #72 (plugin read path) and #75 (migration) read it. Keeping the contract PR free of consumers keeps it reviewable as pure schema design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)