### PR TITLE
feat: core transforms — buildSummary, issue transforms, write-time rendering, atom feed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -332,7 +332,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
       "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.3",
@@ -346,7 +345,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -9178,7 +9176,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -11404,7 +11401,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
       "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
@@ -11424,7 +11420,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
@@ -11477,7 +11472,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -13640,7 +13634,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
       "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
@@ -13849,7 +13842,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -13912,7 +13904,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -14468,7 +14459,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regexp": {
@@ -20105,7 +20095,6 @@
       "version": "2.2.22",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
       "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -23117,7 +23106,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/rtlcss": {
@@ -23224,7 +23212,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -24265,7 +24252,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -24468,7 +24454,6 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
       "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
@@ -24481,7 +24466,6 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -24525,7 +24509,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
@@ -24538,7 +24521,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -25302,7 +25284,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -25357,7 +25338,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -25711,7 +25691,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -25724,7 +25703,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -25737,7 +25715,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -25747,7 +25724,6 @@
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
@@ -25994,7 +25970,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -26004,7 +25979,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/y18n": {
@@ -26110,16 +26084,88 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "chrono-node": "^2.9.0",
+        "dompurify": "^3.3.0",
+        "jsdom": "^25.0.0",
+        "marked": "^17.0.0",
         "zod": "^4.1.12"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/jsdom": "^21.1.7",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.5",
         "typescript": "^5.0.0"
       },
       "engines": {
         "node": ">=20.0"
+      }
+    },
+    "packages/core/node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "packages/core/node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "license": "MIT"
+    },
+    "packages/core/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "packages/docusaurus-plugin-stentorosaur": {

--- a/packages/core/__tests__/transforms.test.ts
+++ b/packages/core/__tests__/transforms.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Core transforms tests (ADR-005 §2/§7; epic #63 ticket #68).
+ *
+ * - issue → incident / maintenance-window transforms (pure; renderHtml injected)
+ * - write-time markdown sanitization (XSS corpus)
+ * - buildSummary determinism (shuffled inputs → identical bytes)
+ * - incidents.atom generation (escaping, determinism)
+ */
+
+import {LabelParser} from '../src/labels';
+import {
+  extractSeverity,
+  isMaintenanceIssue,
+  issueToIncidentV1,
+  worstEntityStatus,
+} from '../src/issues';
+import type {IssuePayload} from '../src/issues';
+import {renderMarkdownToSafeHtml} from '../src/render';
+import {
+  extractFrontmatter,
+  getMaintenanceStatus,
+  issueToMaintenanceV1,
+  parseHumanDate,
+} from '../src/maintenance';
+import {buildSummary} from '../src/build-summary';
+import type {BuildSummaryInputs} from '../src/build-summary';
+import {incidentsToAtom} from '../src/atom';
+import {parseSummary} from '../src/status-v1';
+import type {CompactReading} from '../src/types';
+
+const ENTITIES = [
+  {name: 'api', type: 'system' as const, displayName: 'API'},
+  {name: 'web', type: 'system' as const},
+  {name: 'onboarding', type: 'process' as const},
+];
+const parser = new LabelParser();
+const NOW = '2026-07-12T18:00:00.000Z';
+
+const issue = (over: Partial<IssuePayload> = {}): IssuePayload => ({
+  number: 101,
+  title: 'API outage',
+  state: 'open',
+  created_at: '2026-07-12T17:00:00.000Z',
+  updated_at: '2026-07-12T17:30:00.000Z',
+  html_url: 'https://github.com/o/r/issues/101',
+  body: 'Investigating **elevated** error rates.',
+  labels: [{name: 'status'}, {name: 'critical'}, {name: 'system:api'}],
+  ...over,
+});
+
+describe('severity + entity extraction', () => {
+  it('maps labels to severity with critical > major > minor default', () => {
+    expect(extractSeverity(['critical', 'major'])).toBe('critical');
+    expect(extractSeverity(['major'])).toBe('major');
+    expect(extractSeverity(['status'])).toBe('minor');
+  });
+  it('detects maintenance issues by configured labels', () => {
+    expect(isMaintenanceIssue(['maintenance'], ['maintenance'])).toBe(true);
+    expect(isMaintenanceIssue(['status'], ['maintenance'])).toBe(false);
+  });
+});
+
+describe('issueToIncidentV1', () => {
+  const renderHtml = (md: string) => `<p>${md}</p>`; // injected fake
+  it('produces a valid v1 incident with entity NAMES (not displayNames)', () => {
+    const inc = issueToIncidentV1(issue(), {entities: ENTITIES, labelParser: parser, renderHtml});
+    expect(inc).toEqual({
+      issueNumber: 101,
+      title: 'API outage',
+      severity: 'critical',
+      status: 'open',
+      entities: ['api'],
+      createdAt: '2026-07-12T17:00:00.000Z',
+      closedAt: null,
+      bodyHtml: '<p>Investigating **elevated** error rates.</p>',
+    });
+  });
+  it('closed issues become resolved with closedAt', () => {
+    const inc = issueToIncidentV1(
+      issue({state: 'closed', closed_at: '2026-07-12T17:45:00.000Z', labels: [{name: 'minor'}, {name: 'web'}]}),
+      {entities: ENTITIES, labelParser: parser, renderHtml}
+    );
+    expect(inc.status).toBe('resolved');
+    expect(inc.closedAt).toBe('2026-07-12T17:45:00.000Z');
+    expect(inc.entities).toEqual(['web']); // legacy untyped label
+  });
+});
+
+describe('worstEntityStatus (port of generateStatusItems worst-wins)', () => {
+  const inc = (severity: 'critical' | 'major' | 'minor', entities: string[]) => ({
+    issueNumber: 1,
+    title: 't',
+    severity,
+    status: 'open' as const,
+    entities,
+    createdAt: NOW,
+    closedAt: null,
+    bodyHtml: '',
+  });
+  it('critical → down beats degraded; unaffected entity stays as probe state', () => {
+    expect(worstEntityStatus('up', [inc('critical', ['api'])], 'api')).toBe('down');
+    expect(worstEntityStatus('up', [inc('major', ['api'])], 'api')).toBe('degraded');
+    expect(worstEntityStatus('up', [inc('minor', ['api'])], 'api')).toBe('degraded');
+    expect(worstEntityStatus('up', [inc('critical', ['web'])], 'api')).toBe('up');
+  });
+  it('probe-down wins over incident-degraded; resolved incidents ignored', () => {
+    expect(worstEntityStatus('down', [inc('minor', ['api'])], 'api')).toBe('down');
+    expect(
+      worstEntityStatus('up', [{...inc('critical', ['api']), status: 'resolved' as const}], 'api')
+    ).toBe('up');
+  });
+});
+
+describe('renderMarkdownToSafeHtml (write-time sanitization)', () => {
+  it('renders GFM markdown', () => {
+    const html = renderMarkdownToSafeHtml('**bold** and [link](https://example.com)');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('href="https://example.com"');
+  });
+  it.each([
+    ['<script>alert(1)</script>', '<script'],
+    ['<img src=x onerror=alert(1)>', 'onerror'],
+    ['<a href="javascript:alert(1)">x</a>', 'javascript:'],
+    ['<iframe src="https://evil.example"></iframe>', '<iframe'],
+    ['<div style="background:url(javascript:1)">x</div>', 'style='],
+  ])('neutralizes XSS vector %s', (payload, mustNotContain) => {
+    const html = renderMarkdownToSafeHtml(payload);
+    expect(html.toLowerCase()).not.toContain(mustNotContain.toLowerCase());
+  });
+  it('returns empty string for empty input', () => {
+    expect(renderMarkdownToSafeHtml('')).toBe('');
+  });
+});
+
+describe('maintenance parsing (deterministic: now injected)', () => {
+  it('parses ISO frontmatter and derives status from injected now', () => {
+    const body = '---\nstart: 2026-07-14T02:00:00Z\nend: 2026-07-14T04:00:00Z\n---\n\nDB migration.';
+    const {frontmatter} = extractFrontmatter(body);
+    expect(frontmatter.start).toBe('2026-07-14T02:00:00Z');
+    expect(getMaintenanceStatus(frontmatter.start!, frontmatter.end!, 'open', new Date(NOW))).toBe('upcoming');
+    expect(
+      getMaintenanceStatus('2026-07-12T17:00:00Z', '2026-07-12T19:00:00Z', 'open', new Date(NOW))
+    ).toBe('in-progress');
+    expect(getMaintenanceStatus('2026-07-01T00:00:00Z', '2026-07-01T01:00:00Z', 'open', new Date(NOW))).toBe('completed');
+    expect(getMaintenanceStatus('2026-07-14T02:00:00Z', '2026-07-14T04:00:00Z', 'closed', new Date(NOW))).toBe('completed');
+  });
+  it('parseHumanDate resolves relative dates against the injected reference', () => {
+    const ref = new Date('2026-07-12T00:00:00Z');
+    const parsed = parseHumanDate('tomorrow at 2am UTC', ref);
+    expect(parsed).toMatch(/^2026-07-13T/);
+  });
+  it('skips GitHub issue-form headings before frontmatter', () => {
+    const body = '### Maintenance Details\n\n---\nstart: 2026-07-14T02:00:00Z\nend: 2026-07-14T04:00:00Z\n---\nBody';
+    expect(extractFrontmatter(body).frontmatter.start).toBe('2026-07-14T02:00:00Z');
+  });
+  it('issueToMaintenanceV1 produces a valid window', () => {
+    const win = issueToMaintenanceV1(
+      issue({
+        number: 102,
+        title: 'DB migration',
+        labels: [{name: 'maintenance'}, {name: 'system:api'}],
+        body: '---\nstart: 2026-07-14T02:00:00Z\nend: 2026-07-14T04:00:00Z\n---\n\nRead-only mode.',
+      }),
+      {entities: ENTITIES, labelParser: parser, renderHtml: md => `<p>${md.trim()}</p>`, now: new Date(NOW)}
+    );
+    expect(win).toEqual({
+      issueNumber: 102,
+      title: 'DB migration',
+      start: '2026-07-14T02:00:00Z',
+      end: '2026-07-14T04:00:00Z',
+      status: 'upcoming',
+      entities: ['api'],
+      bodyHtml: '<p>Read-only mode.</p>',
+    });
+  });
+});
+
+describe('buildSummary', () => {
+  const MIN = 60_000;
+  const T = Date.parse(NOW);
+  const readings: CompactReading[] = [
+    {t: T - 10 * MIN, svc: 'api', state: 'up', code: 200, lat: 100},
+    {t: T - 5 * MIN, svc: 'api', state: 'up', code: 200, lat: 140},
+    {t: T - 10 * MIN, svc: 'web', state: 'down', code: 500, lat: 0},
+    {t: T - 5 * MIN, svc: 'web', state: 'down', code: 500, lat: 0},
+  ];
+  const rollups = {
+    api: [
+      {date: '2026-07-11', uptime: 100, avgMs: 120, worst: 'up' as const},
+      {date: '2026-07-12', uptime: 100, avgMs: 120, worst: 'up' as const},
+    ],
+    web: [{date: '2026-07-12', uptime: 50, avgMs: 200, worst: 'down' as const}],
+  };
+  const baseInputs = (): BuildSummaryInputs => ({
+    generatedAt: NOW,
+    generatedBy: 'test@0.0.0',
+    entities: ENTITIES,
+    readings,
+    dailyRollups: rollups,
+    incidents: [
+      {
+        issueNumber: 101, title: 'API outage', severity: 'critical', status: 'open',
+        entities: ['api'], createdAt: '2026-07-12T17:00:00.000Z', closedAt: null, bodyHtml: '<p>x</p>',
+      },
+      {
+        issueNumber: 97, title: 'Old', severity: 'minor', status: 'resolved',
+        entities: ['web'], createdAt: '2026-07-10T09:00:00.000Z', closedAt: '2026-07-10T11:00:00.000Z', bodyHtml: '',
+      },
+    ],
+    maintenance: [
+      {
+        issueNumber: 102, title: 'DB migration', start: '2026-07-14T02:00:00.000Z',
+        end: '2026-07-14T04:00:00.000Z', status: 'upcoming', entities: ['api'], bodyHtml: '',
+      },
+    ],
+  });
+
+  it('produces a summary that parses under the v1 schema', () => {
+    expect(() => parseSummary(JSON.parse(JSON.stringify(buildSummary(baseInputs()))))).not.toThrow();
+  });
+
+  it('entity status is worst of probe state and open incidents', () => {
+    const summary = buildSummary(baseInputs());
+    const api = summary.entities.find(e => e.name === 'api')!;
+    const web = summary.entities.find(e => e.name === 'web')!;
+    const onboarding = summary.entities.find(e => e.name === 'onboarding')!;
+    expect(api.status).toBe('down'); // probe up, but open critical incident
+    expect(web.status).toBe('down'); // probe down
+    expect(onboarding.status).toBe('up'); // no probe, no incidents
+  });
+
+  it('is referentially transparent: shuffled inputs → identical bytes', () => {
+    const a = buildSummary(baseInputs());
+    const shuffled = baseInputs();
+    shuffled.readings = [...shuffled.readings].reverse();
+    shuffled.incidents = [...shuffled.incidents].reverse();
+    shuffled.entities = [...ENTITIES]; // same order — entity order is config-owned
+    const b = buildSummary(shuffled);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('partitions incidents into open/recent and maintenance by status', () => {
+    const s = buildSummary(baseInputs());
+    expect(s.incidents.open.map(i => i.issueNumber)).toEqual([101]);
+    expect(s.incidents.recent.map(i => i.issueNumber)).toEqual([97]);
+    expect(s.maintenance.upcoming.map(m => m.issueNumber)).toEqual([102]);
+    expect(s.maintenance.inProgress).toEqual([]);
+  });
+
+  it('computes d1 uptime/latency from readings and d7/d90 from rollups', () => {
+    const s = buildSummary(baseInputs());
+    const api = s.entities.find(e => e.name === 'api')!;
+    expect(api.uptime.d1).toBe(100);
+    expect(api.responseTimeMs.d1).toBe(120); // (100+140)/2
+    const web = s.entities.find(e => e.name === 'web')!;
+    expect(web.uptime.d1).toBe(0);
+    expect(web.responseTimeMs.d1).toBeNull();
+  });
+});
+
+describe('incidentsToAtom', () => {
+  it('escapes XML and is deterministic', () => {
+    const atom = incidentsToAtom(
+      [
+        {
+          issueNumber: 5, title: 'Outage <&> "quotes"', severity: 'major', status: 'open',
+          entities: ['api'], createdAt: '2026-07-12T17:00:00.000Z', closedAt: null,
+          bodyHtml: '<p>detail & more</p>',
+        },
+      ],
+      {siteTitle: 'Fixture Status', siteUrl: 'https://status.example.com', updated: NOW}
+    );
+    expect(atom).toContain('<?xml version="1.0" encoding="utf-8"?>');
+    expect(atom).toContain('Outage &lt;&amp;&gt; &quot;quotes&quot;');
+    expect(atom).not.toMatch(/<title>[^<]*<&>/);
+    expect(atom).toContain('https://status.example.com');
+    // Deterministic: same inputs → same bytes
+    expect(atom).toBe(
+      incidentsToAtom(
+        [
+          {
+            issueNumber: 5, title: 'Outage <&> "quotes"', severity: 'major', status: 'open',
+            entities: ['api'], createdAt: '2026-07-12T17:00:00.000Z', closedAt: null,
+            bodyHtml: '<p>detail & more</p>',
+          },
+        ],
+        {siteTitle: 'Fixture Status', siteUrl: 'https://status.example.com', updated: NOW}
+      )
+    );
+  });
+});

--- a/packages/core/__tests__/transforms.test.ts
+++ b/packages/core/__tests__/transforms.test.ts
@@ -173,6 +173,26 @@ describe('maintenance parsing (deterministic: now injected)', () => {
       bodyHtml: '<p>Read-only mode.</p>',
     });
   });
+  it('accepts frontmatter-only maintenance bodies', () => {
+    const win = issueToMaintenanceV1(
+      issue({
+        number: 103,
+        title: 'API maintenance',
+        labels: [{name: 'maintenance'}, {name: 'system:api'}],
+        body: '---\nstart: 2026-07-14T02:00:00Z\nend: 2026-07-14T04:00:00Z\n---',
+      }),
+      {entities: ENTITIES, labelParser: parser, renderHtml: md => `<p>${md}</p>`, now: new Date(NOW)}
+    );
+    expect(win).toEqual({
+      issueNumber: 103,
+      title: 'API maintenance',
+      start: '2026-07-14T02:00:00Z',
+      end: '2026-07-14T04:00:00Z',
+      status: 'upcoming',
+      entities: ['api'],
+      bodyHtml: '<p></p>',
+    });
+  });
 });
 
 describe('buildSummary', () => {

--- a/packages/core/__tests__/transforms.test.ts
+++ b/packages/core/__tests__/transforms.test.ts
@@ -127,6 +127,11 @@ describe('renderMarkdownToSafeHtml (write-time sanitization)', () => {
     const html = renderMarkdownToSafeHtml(payload);
     expect(html.toLowerCase()).not.toContain(mustNotContain.toLowerCase());
   });
+  it('forces rel=noopener on target=_blank links (reverse tabnabbing)', () => {
+    const html = renderMarkdownToSafeHtml('<a href="https://x.example" target="_blank">x</a>');
+    expect(html).toContain('target="_blank"');
+    expect(html).toMatch(/rel="[^"]*noopener[^"]*"/);
+  });
   it('returns empty string for empty input', () => {
     expect(renderMarkdownToSafeHtml('')).toBe('');
   });
@@ -135,7 +140,7 @@ describe('renderMarkdownToSafeHtml (write-time sanitization)', () => {
 describe('maintenance parsing (deterministic: now injected)', () => {
   it('parses ISO frontmatter and derives status from injected now', () => {
     const body = '---\nstart: 2026-07-14T02:00:00Z\nend: 2026-07-14T04:00:00Z\n---\n\nDB migration.';
-    const {frontmatter} = extractFrontmatter(body);
+    const {frontmatter} = extractFrontmatter(body, new Date(NOW));
     expect(frontmatter.start).toBe('2026-07-14T02:00:00Z');
     expect(getMaintenanceStatus(frontmatter.start!, frontmatter.end!, 'open', new Date(NOW))).toBe('upcoming');
     expect(
@@ -149,9 +154,27 @@ describe('maintenance parsing (deterministic: now injected)', () => {
     const parsed = parseHumanDate('tomorrow at 2am UTC', ref);
     expect(parsed).toMatch(/^2026-07-13T/);
   });
+  it('systems list survives indented non-dash lines and stops at unindented keys', () => {
+    // Council PR #83 r=1 critical: trim().startsWith(' ') was always false,
+    // so ANY non-dash line (even an indented continuation) ended the list.
+    const body = [
+      '---',
+      'systems:',
+      '  - api',
+      '   ', // indented blank inside the block must not end it
+      '  - web',
+      'start: 2026-07-14T02:00:00Z',
+      'end: 2026-07-14T04:00:00Z',
+      '---',
+      'Body',
+    ].join('\n');
+    const {frontmatter} = extractFrontmatter(body, new Date(NOW));
+    expect(frontmatter.systems).toEqual(['api', 'web']);
+    expect(frontmatter.start).toBe('2026-07-14T02:00:00Z');
+  });
   it('skips GitHub issue-form headings before frontmatter', () => {
     const body = '### Maintenance Details\n\n---\nstart: 2026-07-14T02:00:00Z\nend: 2026-07-14T04:00:00Z\n---\nBody';
-    expect(extractFrontmatter(body).frontmatter.start).toBe('2026-07-14T02:00:00Z');
+    expect(extractFrontmatter(body, new Date(NOW)).frontmatter.start).toBe('2026-07-14T02:00:00Z');
   });
   it('issueToMaintenanceV1 produces a valid window', () => {
     const win = issueToMaintenanceV1(

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -4,4 +4,10 @@ module.exports = {
   roots: ['<rootDir>/src', '<rootDir>/__tests__'],
   testMatch: ['**/__tests__/**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],
+  moduleNameMapper: {
+    // marked v17 ships ESM-only via its exports map; jest's CJS runtime
+    // needs the UMD build. At runtime the compiled lib relies on Node's
+    // require(esm) support (hence engines >= 20.19).
+    '^marked$': '<rootDir>/../../node_modules/marked/lib/marked.umd.js',
+  },
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,15 +23,30 @@
     "@types/jest": "^30.0.0",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.5",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@types/jsdom": "^21.1.7"
   },
   "engines": {
-    "node": ">=20.0"
+    "node": ">=20.19"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
+    "chrono-node": "^2.9.0",
+    "dompurify": "^3.3.0",
+    "jsdom": "^25.0.0",
+    "marked": "^17.0.0",
     "zod": "^4.1.12"
+  },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./server": {
+      "types": "./lib/server.d.ts",
+      "default": "./lib/server.js"
+    }
   }
 }

--- a/packages/core/src/atom.ts
+++ b/packages/core/src/atom.ts
@@ -1,0 +1,67 @@
+/**
+ * incidents.atom — machine-readable incident feed (ADR-005 §2, §11: the
+ * v1.0 substitute for push notifications). Pure and deterministic; the
+ * feed's updated timestamp is injected.
+ */
+
+import type {StatusIncidentV1} from './status-v1';
+
+export interface AtomFeedOptions {
+  siteTitle: string;
+  /** Absolute site URL, no trailing slash required */
+  siteUrl: string;
+  /** ISO timestamp for the feed's <updated> — injected, not clock-read */
+  updated: string;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function incidentsToAtom(
+  incidents: StatusIncidentV1[],
+  options: AtomFeedOptions
+): string {
+  const base = options.siteUrl.replace(/\/+$/, '');
+  const feedId = `${base}/status`;
+
+  const entries = incidents
+    .map(incident => {
+      const entryUpdated = incident.closedAt ?? incident.createdAt;
+      const statusLine =
+        incident.status === 'open'
+          ? `Open ${incident.severity} incident`
+          : `Resolved ${incident.severity} incident`;
+      return [
+        '  <entry>',
+        `    <id>${escapeXml(feedId)}/incidents/${incident.issueNumber}</id>`,
+        `    <title>${escapeXml(incident.title)}</title>`,
+        `    <updated>${escapeXml(entryUpdated)}</updated>`,
+        `    <link href="${escapeXml(`${base}/status`)}"/>`,
+        `    <category term="${escapeXml(incident.severity)}"/>`,
+        `    <summary>${escapeXml(
+          `${statusLine} affecting: ${incident.entities.join(', ') || 'unspecified'}`
+        )}</summary>`,
+        `    <content type="html">${escapeXml(incident.bodyHtml)}</content>`,
+        '  </entry>',
+      ].join('\n');
+    })
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<feed xmlns="http://www.w3.org/2005/Atom">',
+    `  <id>${escapeXml(feedId)}</id>`,
+    `  <title>${escapeXml(options.siteTitle)} — incidents</title>`,
+    `  <updated>${escapeXml(options.updated)}</updated>`,
+    `  <link href="${escapeXml(feedId)}" rel="alternate"/>`,
+    entries,
+    '</feed>',
+    '',
+  ].join('\n');
+}

--- a/packages/core/src/build-summary.ts
+++ b/packages/core/src/build-summary.ts
@@ -1,0 +1,140 @@
+/**
+ * buildSummary — THE deterministic aggregation from probe/issue inputs to
+ * status/v1 summary.json (ADR-005 §2, §5).
+ *
+ * Referential transparency is load-bearing: the regenerate-and-retry
+ * concurrency rule (§5) depends on any writer being able to rebuild an
+ * identical summary from the same merged inputs. Therefore: no clock
+ * reads, no randomness, and all internal ordering is derived from the
+ * inputs (entity order is config-owned; readings are sorted internally).
+ */
+
+import {aggregateSystem, calculateUptimePercent, groupReadingsBySystem} from './aggregate';
+import {encodeDayRollups} from './status-v1';
+import type {DayRollup, StatusIncidentV1, MaintenanceWindowV1, StatusSummary, SummaryEntity} from './status-v1';
+import type {EntityRef} from './labels';
+import type {CompactReading} from './types';
+import {worstEntityStatus} from './issues';
+
+export interface BuildSummaryInputs {
+  /** ISO timestamp — injected, never read from the clock */
+  generatedAt: string;
+  /** e.g. "probe@0.22.0" */
+  generatedBy: string;
+  /** Config-ordered entities (order is preserved in the output) */
+  entities: EntityRef[];
+  /** Recent compact readings (the current.json window) */
+  readings: CompactReading[];
+  /** Per-entity daily rollups, oldest→newest (from archives/daily summary) */
+  dailyRollups: Record<string, DayRollup[]>;
+  /** All transformed incidents (open and resolved) */
+  incidents: StatusIncidentV1[];
+  /** All transformed maintenance windows */
+  maintenance: MaintenanceWindowV1[];
+  /** How many resolved incidents to keep under incidents.recent */
+  recentIncidentLimit?: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function windowUptime(rollups: DayRollup[], days: number): number | null {
+  const window = rollups.slice(-days);
+  if (window.length === 0) return null;
+  const withChecks = window.filter(r => r.uptime >= 0);
+  if (withChecks.length === 0) return null;
+  const sum = withChecks.reduce((acc, r) => acc + r.uptime, 0);
+  return sum / withChecks.length;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export function buildSummary(inputs: BuildSummaryInputs): StatusSummary {
+  const {
+    generatedAt,
+    generatedBy,
+    entities,
+    readings,
+    dailyRollups,
+    incidents,
+    maintenance,
+    recentIncidentLimit = 20,
+  } = inputs;
+
+  const generatedAtMs = Date.parse(generatedAt);
+  const d1Cutoff = generatedAtMs - DAY_MS;
+  const bySystem = groupReadingsBySystem(readings);
+
+  const summaryEntities: SummaryEntity[] = entities.map(entity => {
+    const entityReadings = bySystem.get(entity.name) ?? [];
+    const d1Readings = entityReadings.filter(r => r.t >= d1Cutoff);
+    const agg = aggregateSystem(entity.name, d1Readings);
+    const rollups = dailyRollups[entity.name] ?? [];
+
+    const probeState = agg.latest?.state ?? 'up';
+    const status = worstEntityStatus(probeState, incidents, entity.name);
+
+    const d1FromReadings = d1Readings.length > 0 ? calculateUptimePercent(d1Readings) : null;
+    const d7 = windowUptime(rollups, 7);
+    const d90 = windowUptime(rollups, 90);
+    // Fall back through progressively wider windows so a freshly
+    // bootstrapped site still renders sane numbers.
+    const d1 = d1FromReadings ?? windowUptime(rollups, 1) ?? 100;
+
+    const encodedDays =
+      rollups.length > 0
+        ? encodeDayRollups(rollups.slice(-90))
+        : // no history yet: a single synthetic day derived from d1
+          encodeDayRollups([
+            {
+              date: new Date(generatedAtMs).toISOString().split('T')[0],
+              uptime: round2(d1),
+              avgMs: agg.avgResponseTime ?? null,
+              worst: status,
+            },
+          ]);
+
+    return {
+      name: entity.name,
+      type: entity.type,
+      ...(entity.displayName ? {displayName: entity.displayName} : {}),
+      status,
+      uptime: {
+        d1: round2(d1),
+        d7: round2(d7 ?? d1),
+        d90: round2(d90 ?? d7 ?? d1),
+      },
+      responseTimeMs: {d1: agg.avgResponseTime ?? null},
+      daysEnd: encodedDays.daysEnd,
+      days: encodedDays.days,
+    };
+  });
+
+  const open = incidents
+    .filter(i => i.status === 'open')
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || b.issueNumber - a.issueNumber);
+  const recent = incidents
+    .filter(i => i.status === 'resolved')
+    .sort(
+      (a, b) =>
+        (b.closedAt ?? '').localeCompare(a.closedAt ?? '') || b.issueNumber - a.issueNumber
+    )
+    .slice(0, recentIncidentLimit);
+
+  const upcoming = maintenance
+    .filter(m => m.status === 'upcoming')
+    .sort((a, b) => a.start.localeCompare(b.start) || a.issueNumber - b.issueNumber);
+  const inProgress = maintenance
+    .filter(m => m.status === 'in-progress')
+    .sort((a, b) => a.start.localeCompare(b.start) || a.issueNumber - b.issueNumber);
+
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    generatedBy,
+    entities: summaryEntities,
+    incidents: {open, recent},
+    maintenance: {upcoming, inProgress},
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,4 +8,6 @@
 
 export * from './types';
 export * from './aggregate';
+export * from './labels';
+export * from './issues';
 export * from './status-v1';

--- a/packages/core/src/issues.ts
+++ b/packages/core/src/issues.ts
@@ -1,0 +1,97 @@
+/**
+ * GitHub issue payload → status/v1 transforms (ADR-005 §1: fetching is
+ * I/O and lives in probe; these functions only transform already-fetched
+ * payloads). Pure and client-safe — HTML rendering is INJECTED so the
+ * sanitizer (jsdom-backed, server-only) never enters client bundles.
+ */
+
+import type {LabelParser, EntityRef} from './labels';
+import type {StatusIncidentV1} from './status-v1';
+
+/** The subset of a GitHub REST issue the transforms consume. */
+export interface IssuePayload {
+  number: number;
+  title: string;
+  state: 'open' | 'closed';
+  created_at: string;
+  updated_at: string;
+  closed_at?: string | null;
+  html_url: string;
+  body?: string | null;
+  labels: Array<{name: string}>;
+}
+
+export interface TransformContext {
+  entities: EntityRef[];
+  labelParser: LabelParser;
+  /** Write-time markdown → sanitized HTML (see server-only render.ts) */
+  renderHtml: (markdown: string) => string;
+}
+
+/** Severity from labels: critical > major > minor (default). */
+export function extractSeverity(labels: string[]): 'critical' | 'major' | 'minor' {
+  if (labels.includes('critical')) return 'critical';
+  if (labels.includes('major')) return 'major';
+  return 'minor';
+}
+
+/** Whether the label set marks a scheduled-maintenance issue. */
+export function isMaintenanceIssue(
+  labels: string[],
+  maintenanceLabels: string[]
+): boolean {
+  return labels.some(label => maintenanceLabels.includes(label));
+}
+
+/**
+ * Convert an issue into a status/v1 incident. Entity references use
+ * canonical NAMES (displayName mapping is a presentation concern).
+ */
+export function issueToIncidentV1(
+  issue: IssuePayload,
+  ctx: TransformContext
+): StatusIncidentV1 {
+  const labels = issue.labels.map(l => l.name);
+  return {
+    issueNumber: issue.number,
+    title: issue.title,
+    severity: extractSeverity(labels),
+    status: issue.state === 'closed' ? 'resolved' : 'open',
+    entities: ctx.labelParser
+      .extractEntitiesFromLabels(labels, ctx.entities)
+      .map(e => e.name),
+    createdAt: issue.created_at,
+    closedAt: issue.closed_at ?? null,
+    bodyHtml: ctx.renderHtml(issue.body ?? ''),
+  };
+}
+
+type EntityState = 'up' | 'degraded' | 'down' | 'maintenance';
+
+/**
+ * Worst-wins entity status: starts from the probe-observed state and
+ * escalates for OPEN incidents affecting the entity (port of the
+ * plugin's generateStatusItems ordering: down > degraded > maintenance > up).
+ */
+export function worstEntityStatus(
+  probeState: EntityState,
+  incidents: StatusIncidentV1[],
+  entityName: string
+): EntityState {
+  let status: EntityState = probeState;
+  for (const incident of incidents) {
+    if (incident.status !== 'open') continue;
+    if (!incident.entities.includes(entityName)) continue;
+
+    const incidentStatus: EntityState =
+      incident.severity === 'critical' ? 'down' : 'degraded';
+
+    if (
+      incidentStatus === 'down' ||
+      (incidentStatus === 'degraded' && status !== 'down')
+    ) {
+      status = incidentStatus;
+    }
+  }
+  return status;
+}

--- a/packages/core/src/labels.ts
+++ b/packages/core/src/labels.ts
@@ -1,0 +1,73 @@
+/**
+ * Label parsing for entity identification (ported from the plugin's
+ * label-utils in ticket #68; the plugin copy is deleted at the v1.0
+ * cutover, #77). Pure and client-safe.
+ */
+
+export type EntityType = 'system' | 'process' | 'project' | 'event' | 'sla' | 'custom';
+
+export interface LabelScheme {
+  separator: string;
+  defaultType: EntityType;
+  allowUntyped: boolean;
+}
+
+/** Minimal entity reference used by the transforms. */
+export interface EntityRef {
+  name: string;
+  type: 'system' | 'process';
+  displayName?: string;
+}
+
+export class LabelParser {
+  private scheme: LabelScheme;
+
+  constructor(scheme?: Partial<LabelScheme>) {
+    this.scheme = {
+      separator: scheme?.separator || ':',
+      defaultType: scheme?.defaultType || 'system',
+      allowUntyped: scheme?.allowUntyped ?? true,
+    };
+  }
+
+  /**
+   * Parse a GitHub label into an entity type + name.
+   * Namespaced ('system:api') and simple ('api', via defaultType) forms.
+   */
+  parseLabel(label: string): {type: EntityType; name: string} | null {
+    const {separator, defaultType, allowUntyped} = this.scheme;
+
+    if (label.includes(separator)) {
+      const [typeStr, ...nameParts] = label.split(separator);
+      const name = nameParts.join(separator); // names may contain the separator
+
+      const validTypes: EntityType[] = ['system', 'process', 'project', 'event', 'sla', 'custom'];
+      if (validTypes.includes(typeStr as EntityType)) {
+        return {type: typeStr as EntityType, name};
+      }
+    }
+
+    if (allowUntyped) {
+      return {type: defaultType, name: label};
+    }
+
+    return null;
+  }
+
+  /** Extract known-entity references from a label set. */
+  extractEntitiesFromLabels(
+    labels: string[],
+    knownEntities: Array<{name: string}>
+  ): Array<{type: EntityType; name: string}> {
+    const entityNames = new Set(knownEntities.map(e => e.name));
+    const entities: Array<{type: EntityType; name: string}> = [];
+
+    for (const label of labels) {
+      const parsed = this.parseLabel(label);
+      if (parsed && entityNames.has(parsed.name)) {
+        entities.push(parsed);
+      }
+    }
+    return entities;
+  }
+}

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -1,0 +1,179 @@
+/**
+ * Maintenance-issue parsing (ported from the plugin's maintenance-utils
+ * in ticket #68; deterministic — `now` and reference dates are injected,
+ * never read from the clock). SERVER-ONLY via '@stentorosaur/core/server'
+ * (chrono-node is a write-side dependency).
+ */
+
+import * as chrono from 'chrono-node';
+import type {MaintenanceWindowV1} from './status-v1';
+import type {IssuePayload, TransformContext} from './issues';
+
+export interface MaintenanceFrontmatter {
+  type?: string;
+  start?: string;
+  end?: string;
+  systems?: string[];
+}
+
+/**
+ * Parse human-friendly date strings to ISO 8601.
+ * ISO passthrough, '@tomorrow 2am UTC' shorthand, relative ('+2h').
+ */
+export function parseHumanDate(dateStr: string, referenceDate?: Date): string | null {
+  if (!dateStr || typeof dateStr !== 'string') {
+    return null;
+  }
+  const trimmed = dateStr.trim();
+
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  let processedStr = trimmed;
+  if (processedStr.startsWith('@')) {
+    processedStr = processedStr.substring(1);
+  }
+
+  const parsed = chrono.parseDate(processedStr, referenceDate ?? new Date());
+  if (parsed) {
+    return parsed.toISOString();
+  }
+
+  const fallback = new Date(trimmed);
+  if (!Number.isNaN(fallback.getTime())) {
+    return fallback.toISOString();
+  }
+  return null;
+}
+
+/**
+ * Extract YAML-ish frontmatter from an issue body, skipping GitHub
+ * issue-form headings that precede the first '---' delimiter.
+ */
+export function extractFrontmatter(
+  body: string,
+  referenceDate?: Date
+): {frontmatter: MaintenanceFrontmatter; content: string} {
+  const lines = body.split('\n');
+  let contentStart = 0;
+
+  const firstDelimiterIndex = lines.findIndex(line => line.trim() === '---');
+  if (firstDelimiterIndex !== -1) {
+    while (contentStart < firstDelimiterIndex) {
+      const line = lines[contentStart].trim();
+      if (line.startsWith('#') || line === '') {
+        contentStart++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  const cleanedBody = lines.slice(contentStart).join('\n');
+  const match = cleanedBody.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!match) {
+    return {frontmatter: {}, content: cleanedBody};
+  }
+
+  const [, frontmatterText, content] = match;
+  const frontmatter: MaintenanceFrontmatter = {};
+  const frontmatterLines = frontmatterText.split('\n');
+
+  for (const line of frontmatterLines) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex === -1) continue;
+    const key = line.substring(0, colonIndex).trim();
+    const value = line.substring(colonIndex + 1).trim();
+
+    if (key === 'type') {
+      frontmatter.type = value;
+    } else if (key === 'start') {
+      frontmatter.start = parseHumanDate(value, referenceDate) || value;
+    } else if (key === 'end') {
+      frontmatter.end = parseHumanDate(value, referenceDate) || value;
+    } else if (key === 'systems') {
+      const systemsStart = frontmatterLines.indexOf(line);
+      const systems: string[] = [];
+      for (let i = systemsStart + 1; i < frontmatterLines.length; i++) {
+        const systemLine = frontmatterLines[i];
+        if (systemLine.trim().startsWith('-')) {
+          systems.push(systemLine.trim().substring(1).trim());
+        } else if (!systemLine.trim().startsWith(' ')) {
+          break;
+        }
+      }
+      if (systems.length > 0) {
+        frontmatter.systems = systems;
+      }
+    }
+  }
+
+  return {frontmatter, content};
+}
+
+/**
+ * Maintenance window status from its times and issue state, evaluated
+ * against an INJECTED `now` (determinism: buildSummary must be a pure
+ * function of its inputs).
+ */
+export function getMaintenanceStatus(
+  start: string,
+  end: string,
+  issueState: 'open' | 'closed',
+  now: Date
+): MaintenanceWindowV1['status'] {
+  if (issueState === 'closed') {
+    return 'completed';
+  }
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  if (now >= startDate && now <= endDate) {
+    return 'in-progress';
+  }
+  if (now < startDate) {
+    return 'upcoming';
+  }
+  return 'completed';
+}
+
+export interface MaintenanceTransformContext extends TransformContext {
+  now: Date;
+}
+
+/**
+ * Convert a maintenance issue into a status/v1 window. Returns null when
+ * the frontmatter lacks parseable start/end times (malformed tickets are
+ * skipped, never fatal — the probe reports them separately).
+ */
+export function issueToMaintenanceV1(
+  issue: IssuePayload,
+  ctx: MaintenanceTransformContext
+): MaintenanceWindowV1 | null {
+  const {frontmatter, content} = extractFrontmatter(issue.body ?? '', ctx.now);
+  if (!frontmatter.start || !frontmatter.end) {
+    return null;
+  }
+  const start = Date.parse(frontmatter.start);
+  const end = Date.parse(frontmatter.end);
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    return null;
+  }
+
+  const labels = issue.labels.map(l => l.name);
+  const labelEntities = ctx.labelParser
+    .extractEntitiesFromLabels(labels, ctx.entities)
+    .map(e => e.name);
+  const knownNames = new Set(ctx.entities.map(e => e.name));
+  const frontmatterEntities = (frontmatter.systems ?? []).filter(s => knownNames.has(s));
+
+  return {
+    issueNumber: issue.number,
+    title: issue.title,
+    start: frontmatter.start,
+    end: frontmatter.end,
+    status: getMaintenanceStatus(frontmatter.start, frontmatter.end, issue.state, ctx.now),
+    entities: [...new Set([...labelEntities, ...frontmatterEntities])],
+    bodyHtml: ctx.renderHtml(content),
+  };
+}

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -19,8 +19,11 @@ export interface MaintenanceFrontmatter {
 /**
  * Parse human-friendly date strings to ISO 8601.
  * ISO passthrough, '@tomorrow 2am UTC' shorthand, relative ('+2h').
+ *
+ * `referenceDate` is REQUIRED: this module is chartered deterministic
+ * (ADR-005 §5) — callers inject their `now`, never the system clock.
  */
-export function parseHumanDate(dateStr: string, referenceDate?: Date): string | null {
+export function parseHumanDate(dateStr: string, referenceDate: Date): string | null {
   if (!dateStr || typeof dateStr !== 'string') {
     return null;
   }
@@ -35,7 +38,7 @@ export function parseHumanDate(dateStr: string, referenceDate?: Date): string | 
     processedStr = processedStr.substring(1);
   }
 
-  const parsed = chrono.parseDate(processedStr, referenceDate ?? new Date());
+  const parsed = chrono.parseDate(processedStr, referenceDate);
   if (parsed) {
     return parsed.toISOString();
   }
@@ -53,7 +56,7 @@ export function parseHumanDate(dateStr: string, referenceDate?: Date): string | 
  */
 export function extractFrontmatter(
   body: string,
-  referenceDate?: Date
+  referenceDate: Date
 ): {frontmatter: MaintenanceFrontmatter; content: string} {
   const lines = body.split('\n');
   let contentStart = 0;
@@ -85,7 +88,8 @@ export function extractFrontmatter(
   const frontmatter: MaintenanceFrontmatter = {};
   const frontmatterLines = frontmatterText.split('\n');
 
-  for (const line of frontmatterLines) {
+  for (let lineIndex = 0; lineIndex < frontmatterLines.length; lineIndex++) {
+    const line = frontmatterLines[lineIndex];
     const colonIndex = line.indexOf(':');
     if (colonIndex === -1) continue;
     const key = line.substring(0, colonIndex).trim();
@@ -98,13 +102,15 @@ export function extractFrontmatter(
     } else if (key === 'end') {
       frontmatter.end = parseHumanDate(value, referenceDate) || value;
     } else if (key === 'systems') {
-      const systemsStart = frontmatterLines.indexOf(line);
       const systems: string[] = [];
-      for (let i = systemsStart + 1; i < frontmatterLines.length; i++) {
+      for (let i = lineIndex + 1; i < frontmatterLines.length; i++) {
         const systemLine = frontmatterLines[i];
         if (systemLine.trim().startsWith('-')) {
           systems.push(systemLine.trim().substring(1).trim());
-        } else if (!systemLine.trim().startsWith(' ')) {
+        } else if (!systemLine.startsWith(' ')) {
+          // Unindented line: the list block has ended. Indented non-dash
+          // lines (e.g. stray blanks) are skipped, not terminal —
+          // Council PR #83 r=1: trim().startsWith(' ') was always false.
           break;
         }
       }

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -71,12 +71,17 @@ export function extractFrontmatter(
   }
 
   const cleanedBody = lines.slice(contentStart).join('\n');
-  const match = cleanedBody.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
-  if (!match) {
+  const cleanedLines = cleanedBody.split('\n');
+  if (cleanedLines[0]?.trim() !== '---') {
+    return {frontmatter: {}, content: cleanedBody};
+  }
+  const closingDelimiterIndex = cleanedLines.findIndex((line, index) => index > 0 && line.trim() === '---');
+  if (closingDelimiterIndex === -1) {
     return {frontmatter: {}, content: cleanedBody};
   }
 
-  const [, frontmatterText, content] = match;
+  const frontmatterText = cleanedLines.slice(1, closingDelimiterIndex).join('\n');
+  const content = cleanedLines.slice(closingDelimiterIndex + 1).join('\n');
   const frontmatter: MaintenanceFrontmatter = {};
   const frontmatterLines = frontmatterText.split('\n');
 

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -10,12 +10,24 @@
  * utils/markdown.ts so rendered output is identical during migration.
  */
 
-import {marked} from 'marked';
+import {Marked} from 'marked';
 import createDOMPurify from 'dompurify';
 import {JSDOM} from 'jsdom';
 
 const window = new JSDOM('').window;
 const DOMPurify = createDOMPurify(window as unknown as Parameters<typeof createDOMPurify>[0]);
+
+// Reverse-tabnabbing guard: any link carrying target must also carry
+// rel="noopener noreferrer" (target stays allowed for renderer parity
+// with the plugin's client-side markdown component).
+DOMPurify.addHook('afterSanitizeAttributes', node => {
+  if (node.tagName === 'A' && node.hasAttribute('target')) {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
+// Instance renderer: no global marked.setOptions mutation per call.
+const renderer = new Marked({gfm: true, breaks: true});
 
 const ALLOWED_TAGS = [
   'p', 'br', 'strong', 'em', 'u', 's', 'code', 'pre',
@@ -33,8 +45,7 @@ const ALLOWED_ATTR = ['href', 'title', 'src', 'alt', 'target', 'rel'];
 export function renderMarkdownToSafeHtml(markdown: string | undefined): string {
   if (!markdown) return '';
 
-  marked.setOptions({gfm: true, breaks: true});
-  const html = marked.parse(markdown) as string;
+  const html = renderer.parse(markdown) as string;
 
   return DOMPurify.sanitize(html, {ALLOWED_TAGS, ALLOWED_ATTR}).trim();
 }

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -1,0 +1,40 @@
+/**
+ * Write-time markdown → sanitized HTML (ADR-005 §2/§7). SERVER-ONLY:
+ * jsdom-backed DOMPurify must never enter client bundles — this module
+ * is exported via the '@stentorosaur/core/server' subpath, not the
+ * package root. Raw markdown is always retained under status/v1/raw/ so
+ * a sanitizer CVE can be answered by re-rendering (stentorosaur
+ * regenerate).
+ *
+ * The tag/attribute allowlist matches the plugin's client-side
+ * utils/markdown.ts so rendered output is identical during migration.
+ */
+
+import {marked} from 'marked';
+import createDOMPurify from 'dompurify';
+import {JSDOM} from 'jsdom';
+
+const window = new JSDOM('').window;
+const DOMPurify = createDOMPurify(window as unknown as Parameters<typeof createDOMPurify>[0]);
+
+const ALLOWED_TAGS = [
+  'p', 'br', 'strong', 'em', 'u', 's', 'code', 'pre',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'ul', 'ol', 'li',
+  'blockquote',
+  'a',
+  'img',
+  'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  'hr',
+  'del', 'ins',
+];
+const ALLOWED_ATTR = ['href', 'title', 'src', 'alt', 'target', 'rel'];
+
+export function renderMarkdownToSafeHtml(markdown: string | undefined): string {
+  if (!markdown) return '';
+
+  marked.setOptions({gfm: true, breaks: true});
+  const html = marked.parse(markdown) as string;
+
+  return DOMPurify.sanitize(html, {ALLOWED_TAGS, ALLOWED_ATTR}).trim();
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -1,0 +1,12 @@
+/**
+ * '@stentorosaur/core/server' — write-side entry point (ADR-005 §2).
+ *
+ * SERVER-ONLY: pulls in jsdom (sanitizer) and chrono-node (human dates).
+ * Client bundles must import from the package root instead; the root
+ * index deliberately does NOT re-export this module.
+ */
+
+export * from './render';
+export * from './maintenance';
+export * from './build-summary';
+export * from './atom';


### PR DESCRIPTION
Closes #68

Part of epic #63 (ADR-005), Phase 2.

## Changes

- **`@stentorosaur/core/server` subpath** (new exports map): write-side modules — markdown rendering (marked + jsdom-backed DOMPurify, allowlist identical to the client renderer), maintenance parsing (chrono-node), `buildSummary`, atom feed. The package ROOT stays client-safe: theme components can never accidentally pull jsdom into a webpack bundle; `renderHtml` is dependency-injected into the pure issue transforms.
- **`buildSummary(inputs) → StatusSummary`**: deterministic by construction — `generatedAt`/`now` injected, entity order config-owned, all internal ordering derived from inputs. Test asserts shuffled inputs → byte-identical output (the §5 regenerate-and-retry rule depends on this).
- **Issue transforms**: `issueToIncidentV1` (severity, label-parsed entity names, injected rendering), `issueToMaintenanceV1` (frontmatter + human dates with injected reference; malformed tickets return null, never throw), `worstEntityStatus` (ports generateStatusItems worst-wins; probe state escalated by open incidents).
- **incidents.atom** generator (escaped, deterministic) — the §11 notification substitute.
- **marked v17 is ESM-only**: runtime relies on Node's require(esm) → core `engines` bumped to `>=20.19`; jest maps `marked` to its UMD build. Flagged for review — the alternative (pin marked ≤4) trades a maintained dep for CJS purity.

## Scope notes

- Plugin internals deliberately untouched (its LabelParser/maintenance-utils copies die at the #77 cutover) — zero behavior change to the published package in this PR.
- Demo-parity check deferred to #75: demo data is in the LEGACY shape; mapping legacy→v1 is exactly the migration ticket's transform.
- Council/Copilot nits from #82 addressed here as promised: transforms are the first `encodeDayRollups` caller and sort before encoding.

## Test plan (TDD: suite written first, failed on missing modules)

- 23 new tests: severity/entity extraction, incident/maintenance transforms, XSS corpus (script/onerror/javascript:/iframe/style), injected-now status derivation, buildSummary schema-validity + determinism + d1/d7/d90 windows + partitioning, atom escaping/determinism
- Core 59 green; plugin 733 green (untouched); typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)