### PR TITLE
feat: probe engine — native-fetch checks, parallel per-entity files, regenerate-and-retry writer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26098,7 +26098,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20.19"
       }
     },
     "packages/core/node_modules/jsdom": {
@@ -26227,10 +26227,19 @@
     },
     "packages/probe": {
       "name": "@stentorosaur/probe",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@stentorosaur/core": "^0.1.0"
+      },
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "jest": "^30.2.0",
+        "ts-jest": "^29.4.5",
+        "typescript": "^5.0.0"
+      },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20.19"
       }
     }
   }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2022"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "composite": true,
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/probe/__tests__/check.test.ts
+++ b/packages/probe/__tests__/check.test.ts
@@ -119,6 +119,25 @@ describe('checkEndpoint', () => {
     expect(reading.code).toBe(0);
     expect(reading.err).toBeDefined();
   });
+
+  it('passes through supported non-GET methods', async () => {
+    const fetchImpl = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {status: 204})
+    );
+
+    const reading = await checkEndpoint(
+      target({method: 'DELETE', expectedCodes: [204]}),
+      Date.now(),
+      fetchImpl
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      `${base}/ok`,
+      expect.objectContaining({method: 'DELETE'})
+    );
+    expect(reading.state).toBe('up');
+    expect(reading.code).toBe(204);
+  });
 });
 
 describe('runChecks', () => {

--- a/packages/probe/__tests__/check.test.ts
+++ b/packages/probe/__tests__/check.test.ts
@@ -166,4 +166,12 @@ describe('runChecks', () => {
     const readings = await runChecks(targets, {concurrency: 3});
     expect(readings.map(r => r.svc)).toEqual(['alpha', 'beta', 'gamma']);
   });
+
+  it('sanitizes pathological concurrency values (Council PR #84 r=1: NaN → zero workers)', async () => {
+    for (const concurrency of [NaN, 0, -1, 2.7] as number[]) {
+      const readings = await runChecks(targets, {concurrency});
+      expect(readings.map(r => r.svc)).toEqual(['alpha', 'beta', 'gamma']);
+      expect(readings.every(r => r !== undefined)).toBe(true);
+    }
+  });
 });

--- a/packages/probe/__tests__/check.test.ts
+++ b/packages/probe/__tests__/check.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Probe check-engine tests (ADR-005 §1/§6; epic #63 ticket #69).
+ * Real HTTP against a local mock server — parity with monitor.js
+ * semantics: 0/unexpected code → down; slow → degraded; else up.
+ */
+
+import http from 'node:http';
+import {AddressInfo} from 'node:net';
+import {checkEndpoint, determineStatus, runChecks} from '../src/check';
+import type {CheckTarget} from '../src/check';
+
+let server: http.Server;
+let base: string;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    if (req.url === '/ok') {
+      res.writeHead(200);
+      res.end('ok');
+    } else if (req.url === '/redirect-target-code') {
+      res.writeHead(301, {location: '/ok'});
+      res.end();
+    } else if (req.url === '/fail') {
+      res.writeHead(500);
+      res.end('boom');
+    } else if (req.url === '/slow') {
+      setTimeout(() => {
+        res.writeHead(200);
+        res.end('slow');
+      }, 300);
+    } else if (req.url === '/hang') {
+      // never respond — exercises the timeout path
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+const target = (over: Partial<CheckTarget> = {}): CheckTarget => ({
+  system: 'api',
+  url: `${base}/ok`,
+  method: 'GET',
+  timeout: 2000,
+  expectedCodes: [200],
+  maxResponseTime: 30000,
+  ...over,
+});
+
+describe('determineStatus (monitor.js parity)', () => {
+  it.each([
+    [0, 100, [200], 30000, 'down'],
+    [500, 100, [200], 30000, 'down'],
+    [301, 100, [200, 301], 30000, 'up'],
+    [200, 100, [200], 30000, 'up'],
+    [200, 31000, [200], 30000, 'degraded'],
+  ] as const)('code=%s time=%s expected=%s max=%s → %s', (code, time, expected, max, want) => {
+    expect(determineStatus(code, time, [...expected], max)).toBe(want);
+  });
+});
+
+describe('checkEndpoint', () => {
+  it('measures an up endpoint', async () => {
+    const reading = await checkEndpoint(target(), Date.now());
+    expect(reading.state).toBe('up');
+    expect(reading.code).toBe(200);
+    expect(reading.lat).toBeGreaterThanOrEqual(0);
+    expect(reading.err).toBeUndefined();
+  });
+
+  it('unexpected status code → down with err', async () => {
+    const reading = await checkEndpoint(target({url: `${base}/fail`}), Date.now());
+    expect(reading.state).toBe('down');
+    expect(reading.code).toBe(500);
+    expect(reading.err).toBeDefined();
+  });
+
+  it('non-2xx codes can be EXPECTED (redirect monitoring)', async () => {
+    const reading = await checkEndpoint(
+      target({url: `${base}/redirect-target-code`, expectedCodes: [301]}),
+      Date.now()
+    );
+    expect(reading.state).toBe('up');
+    expect(reading.code).toBe(301);
+  });
+
+  it('response slower than maxResponseTime → degraded', async () => {
+    const reading = await checkEndpoint(
+      target({url: `${base}/slow`, maxResponseTime: 50}),
+      Date.now()
+    );
+    expect(reading.state).toBe('degraded');
+    expect(reading.code).toBe(200);
+    expect(reading.lat).toBeGreaterThanOrEqual(50);
+  });
+
+  it('timeout → down, code 0, err set', async () => {
+    const reading = await checkEndpoint(
+      target({url: `${base}/hang`, timeout: 200}),
+      Date.now()
+    );
+    expect(reading.state).toBe('down');
+    expect(reading.code).toBe(0);
+    expect(reading.err).toMatch(/timeout/i);
+  }, 10000);
+
+  it('connection refused → down, code 0', async () => {
+    const reading = await checkEndpoint(
+      target({url: 'http://127.0.0.1:1/nope', timeout: 500}),
+      Date.now()
+    );
+    expect(reading.state).toBe('down');
+    expect(reading.code).toBe(0);
+    expect(reading.err).toBeDefined();
+  });
+});
+
+describe('runChecks', () => {
+  const targets: CheckTarget[] = [
+    {system: 'alpha', url: '', method: 'GET', timeout: 2000, expectedCodes: [200], maxResponseTime: 30000},
+    {system: 'beta', url: '', method: 'GET', timeout: 2000, expectedCodes: [200], maxResponseTime: 30000},
+    {system: 'gamma', url: '', method: 'GET', timeout: 2000, expectedCodes: [200], maxResponseTime: 30000},
+  ];
+  beforeAll(() => {
+    targets[0].url = `${base}/ok`;
+    targets[1].url = `${base}/fail`;
+    targets[2].url = `${base}/ok`;
+  });
+
+  const normalize = (readings: Array<{svc: string; state: string; code: number}>) =>
+    readings.map(r => ({svc: r.svc, state: r.state, code: r.code}));
+
+  it('parallel run covers every target exactly once, same outcomes as sequential', async () => {
+    const parallel = await runChecks(targets, {concurrency: 3});
+    const sequential = await runChecks(targets, {concurrency: 1});
+    expect(normalize(parallel)).toEqual(normalize(sequential));
+    expect(parallel.map(r => r.svc).sort()).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('preserves target order in the result regardless of completion order', async () => {
+    const readings = await runChecks(targets, {concurrency: 3});
+    expect(readings.map(r => r.svc)).toEqual(['alpha', 'beta', 'gamma']);
+  });
+});

--- a/packages/probe/__tests__/files.test.ts
+++ b/packages/probe/__tests__/files.test.ts
@@ -6,7 +6,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import {appendArchive, entitySlug, readAllEntityDetails, writeEntityDetail} from '../src/files';
+import {appendArchive, assertUniqueSlugs, entitySlug, readAllEntityDetails, writeEntityDetail} from '../src/files';
 import type {CompactReading} from '@stentorosaur/core';
 
 let tmp: string;
@@ -31,6 +31,25 @@ describe('entitySlug', () => {
     expect(entitySlug('My API (v2)')).toBe('my-api-v2');
     expect(entitySlug('api')).toBe('api');
   });
+  it('trims leading/trailing hyphens (Council PR #84 r=1)', () => {
+    expect(entitySlug('-api-')).toBe('api');
+    expect(entitySlug('  api  ')).toBe('api');
+  });
+  it('never returns empty: symbol-only names get a deterministic hex slug', () => {
+    const slug = entitySlug('!!!');
+    expect(slug).toMatch(/^entity-[0-9a-f]+$/);
+    expect(entitySlug('!!!')).toBe(slug); // deterministic
+    expect(entitySlug('???')).not.toBe(slug); // distinct inputs stay distinct
+  });
+});
+
+describe('assertUniqueSlugs', () => {
+  it('throws listing colliding names (silent-overwrite guard)', () => {
+    expect(() => assertUniqueSlugs(['API v1', 'API-v1', 'web'])).toThrow(/API v1.*API-v1.*api-v1/s);
+  });
+  it('passes for distinct slugs', () => {
+    expect(() => assertUniqueSlugs(['api', 'web', 'My API (v2)'])).not.toThrow();
+  });
 });
 
 describe('writeEntityDetail / readAllEntityDetails', () => {
@@ -47,6 +66,17 @@ describe('writeEntityDetail / readAllEntityDetails', () => {
       writeEntityDetail(tmp, 'api', [{...reading(), state: 'sideways' as any}], '2026-07-12T18:00:00.000Z')
     ).toThrow();
     expect(readAllEntityDetails(tmp)).toEqual([]);
+  });
+
+  it('skips malformed files instead of aborting the run (Council PR #84 r=1)', () => {
+    writeEntityDetail(tmp, 'api', [reading()], '2026-07-12T18:00:00.000Z');
+    const dir = path.join(tmp, 'status', 'v1', 'entities');
+    fs.writeFileSync(path.join(dir, 'corrupt.json'), '{not json');
+    fs.writeFileSync(path.join(dir, 'wrong-shape.json'), '{"schemaVersion":1}');
+    const errors: string[] = [];
+    const details = readAllEntityDetails(tmp, file => errors.push(path.basename(file)));
+    expect(details.map(d => d.name)).toEqual(['api']);
+    expect(errors.sort()).toEqual(['corrupt.json', 'wrong-shape.json']);
   });
 });
 

--- a/packages/probe/__tests__/files.test.ts
+++ b/packages/probe/__tests__/files.test.ts
@@ -43,6 +43,21 @@ describe('entitySlug', () => {
   });
 });
 
+describe('write-site slug collision enforcement', () => {
+  it('refuses to overwrite a DIFFERENT entity sharing the slug', () => {
+    writeEntityDetail(tmp, 'API v1', [reading({svc: 'API v1'})], '2026-07-12T18:00:00.000Z');
+    expect(() =>
+      writeEntityDetail(tmp, 'API-v1', [reading({svc: 'API-v1'})], '2026-07-12T18:00:00.000Z')
+    ).toThrow(/slug collision/);
+  });
+  it('allows re-writing the SAME entity', () => {
+    writeEntityDetail(tmp, 'api', [reading()], '2026-07-12T18:00:00.000Z');
+    expect(() =>
+      writeEntityDetail(tmp, 'api', [reading({lat: 99})], '2026-07-12T18:00:00.000Z')
+    ).not.toThrow();
+  });
+});
+
 describe('assertUniqueSlugs', () => {
   it('throws listing colliding names (silent-overwrite guard)', () => {
     expect(() => assertUniqueSlugs(['API v1', 'API-v1', 'web'])).toThrow(/API v1.*API-v1.*api-v1/s);

--- a/packages/probe/__tests__/files.test.ts
+++ b/packages/probe/__tests__/files.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-entity file layer tests (ticket #69): parallel-safe writes (one
+ * file per entity), ADR-002 JSONL archive layout, write-side validation.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {appendArchive, entitySlug, readAllEntityDetails, writeEntityDetail} from '../src/files';
+import type {CompactReading} from '@stentorosaur/core';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'probe-files-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, {recursive: true, force: true});
+});
+
+const reading = (over: Partial<CompactReading> = {}): CompactReading => ({
+  t: Date.UTC(2026, 6, 12, 18),
+  svc: 'api',
+  state: 'up',
+  code: 200,
+  lat: 42,
+  ...over,
+});
+
+describe('entitySlug', () => {
+  it('matches the plugin slug rules', () => {
+    expect(entitySlug('My API (v2)')).toBe('my-api-v2');
+    expect(entitySlug('api')).toBe('api');
+  });
+});
+
+describe('writeEntityDetail / readAllEntityDetails', () => {
+  it('round-trips through validated per-entity files', () => {
+    writeEntityDetail(tmp, 'api', [reading()], '2026-07-12T18:00:00.000Z');
+    writeEntityDetail(tmp, 'web', [reading({svc: 'web', state: 'down', code: 500, lat: 0})], '2026-07-12T18:00:00.000Z');
+    const details = readAllEntityDetails(tmp);
+    expect(details.map(d => d.name)).toEqual(['api', 'web']);
+    expect(details[0].readings[0].code).toBe(200);
+  });
+
+  it('rejects invalid readings at WRITE time', () => {
+    expect(() =>
+      writeEntityDetail(tmp, 'api', [{...reading(), state: 'sideways' as any}], '2026-07-12T18:00:00.000Z')
+    ).toThrow();
+    expect(readAllEntityDetails(tmp)).toEqual([]);
+  });
+});
+
+describe('appendArchive', () => {
+  it('appends JSONL under archives/YYYY/MM/history-YYYY-MM-DD.jsonl (UTC)', () => {
+    const file = appendArchive(tmp, reading());
+    expect(file.endsWith(path.join('archives', '2026', '07', 'history-2026-07-12.jsonl'))).toBe(true);
+    appendArchive(tmp, reading({lat: 43}));
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1]).lat).toBe(43);
+  });
+});

--- a/packages/probe/__tests__/git-writer.test.ts
+++ b/packages/probe/__tests__/git-writer.test.ts
@@ -59,6 +59,32 @@ function writerOps(entity: string, value: string) {
 const noJitter = {sleep: async () => {}, jitterMs: () => 0};
 
 describe('pushWithRegenerateRetry', () => {
+  it('commits WITHOUT any ambient git identity (stateless CI runners)', async () => {
+    // Council PR #84 r=1 critical: commit must not depend on global config.
+    const dir = path.join(tmp, 'bare-identity');
+    execFileSync('git', ['clone', origin, dir], {stdio: 'pipe'});
+    // Deliberately NO git config user.* here; also hide global/system config.
+    const saved = {...process.env};
+    process.env.GIT_CONFIG_GLOBAL = '/dev/null';
+    process.env.GIT_CONFIG_SYSTEM = '/dev/null';
+    try {
+      await pushWithRegenerateRetry({
+        workdir: dir,
+        branch: 'status-data',
+        commitMessage: 'probe: identityless',
+        ...writerOps('alpha', 'v1'),
+        ...noJitter,
+      });
+    } finally {
+      process.env.GIT_CONFIG_GLOBAL = saved.GIT_CONFIG_GLOBAL;
+      process.env.GIT_CONFIG_SYSTEM = saved.GIT_CONFIG_SYSTEM;
+      if (saved.GIT_CONFIG_GLOBAL === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+      if (saved.GIT_CONFIG_SYSTEM === undefined) delete process.env.GIT_CONFIG_SYSTEM;
+    }
+    const verify = makeClone('verify-identity');
+    expect(fs.existsSync(path.join(verify, 'status', 'v1', 'entities', 'alpha.json'))).toBe(true);
+  });
+
   it('first write initializes the branch', async () => {
     const clone = makeClone('a');
     await pushWithRegenerateRetry({

--- a/packages/probe/__tests__/git-writer.test.ts
+++ b/packages/probe/__tests__/git-writer.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regenerate-and-retry git writer tests (ADR-005 §5; ticket #69).
+ *
+ * The §5 rule: summary.json is a pure function of the merged inputs, so
+ * a writer losing a push race re-fetches, re-writes ITS OWN inputs on
+ * top, regenerates, and retries. Tested against REAL git repos: a bare
+ * "origin" and two racing clones — no lost readings, converged summary.
+ */
+
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {pushWithRegenerateRetry} from '../src/git-writer';
+
+const git = (cwd: string, ...args: string[]) =>
+  execFileSync('git', args, {cwd, stdio: 'pipe'}).toString();
+
+let tmp: string;
+let origin: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'probe-git-'));
+  origin = path.join(tmp, 'origin.git');
+  execFileSync('git', ['init', '--bare', '--initial-branch=status-data', origin]);
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, {recursive: true, force: true});
+});
+
+function makeClone(name: string): string {
+  const dir = path.join(tmp, name);
+  execFileSync('git', ['clone', origin, dir], {stdio: 'pipe'});
+  git(dir, 'config', 'user.email', 'probe@test');
+  git(dir, 'config', 'user.name', 'probe');
+  return dir;
+}
+
+/** writeInputs writes one entity file; regenerate merges all inputs. */
+function writerOps(entity: string, value: string) {
+  return {
+    writeInputs: async (workdir: string) => {
+      const dir = path.join(workdir, 'status', 'v1', 'entities');
+      fs.mkdirSync(dir, {recursive: true});
+      fs.writeFileSync(path.join(dir, `${entity}.json`), JSON.stringify({entity, value}));
+    },
+    regenerate: async (workdir: string) => {
+      const dir = path.join(workdir, 'status', 'v1', 'entities');
+      const files = fs.existsSync(dir) ? fs.readdirSync(dir).sort() : [];
+      fs.writeFileSync(
+        path.join(workdir, 'status', 'v1', 'summary.json'),
+        JSON.stringify({from: files})
+      );
+    },
+  };
+}
+
+const noJitter = {sleep: async () => {}, jitterMs: () => 0};
+
+describe('pushWithRegenerateRetry', () => {
+  it('first write initializes the branch', async () => {
+    const clone = makeClone('a');
+    await pushWithRegenerateRetry({
+      workdir: clone,
+      branch: 'status-data',
+      commitMessage: 'probe: alpha',
+      ...writerOps('alpha', 'v1'),
+      ...noJitter,
+    });
+    const verify = makeClone('verify');
+    expect(fs.existsSync(path.join(verify, 'status', 'v1', 'entities', 'alpha.json'))).toBe(true);
+  });
+
+  it('losing a race retries and converges with NO lost inputs (§5)', async () => {
+    const a = makeClone('a');
+    const b = makeClone('b');
+
+    // Seed: writer A lands first.
+    await pushWithRegenerateRetry({
+      workdir: a,
+      branch: 'status-data',
+      commitMessage: 'probe: alpha',
+      ...writerOps('alpha', 'v1'),
+      ...noJitter,
+    });
+
+    // Writer B is STALE (cloned before A pushed? No — clone happened before
+    // A's push, so B has no status-data commits). B's push must hit
+    // non-fast-forward, refetch, and land on top.
+    await pushWithRegenerateRetry({
+      workdir: b,
+      branch: 'status-data',
+      commitMessage: 'probe: beta',
+      ...writerOps('beta', 'v1'),
+      ...noJitter,
+    });
+
+    const verify = makeClone('verify2');
+    const entities = fs.readdirSync(path.join(verify, 'status', 'v1', 'entities')).sort();
+    expect(entities).toEqual(['alpha.json', 'beta.json']);
+    // Summary regenerated from the MERGED inputs, not just B's own.
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(verify, 'status', 'v1', 'summary.json'), 'utf8')
+    );
+    expect(summary.from).toEqual(['alpha.json', 'beta.json']);
+  });
+
+  it('gives up loudly after maxRetries consecutive rejections', async () => {
+    const a = makeClone('a');
+    let pushes = 0;
+    await expect(
+      pushWithRegenerateRetry({
+        workdir: a,
+        branch: 'status-data',
+        commitMessage: 'probe: alpha',
+        ...writerOps('alpha', 'v1'),
+        ...noJitter,
+        maxRetries: 2,
+        // Sabotage: another commit lands on origin before EVERY push.
+        beforePush: async () => {
+          pushes++;
+          const saboteur = makeClone(`saboteur-${pushes}`);
+          await pushWithRegenerateRetry({
+            workdir: saboteur,
+            branch: 'status-data',
+            commitMessage: `saboteur ${pushes}`,
+            ...writerOps(`ghost-${pushes}`, 'x'),
+            ...noJitter,
+          });
+        },
+      })
+    ).rejects.toThrow(/retries|non-fast-forward|rejected/i);
+    expect(pushes).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/probe/jest.config.js
+++ b/packages/probe/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/__tests__'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  // 30s default: the git-writer integration tests spawn real git processes
+  testTimeout: 30000,
+  moduleNameMapper: {
+    // Resolve workspace-sibling core from source; marked v17 is ESM-only
+    // so jest's CJS runtime uses the UMD build (same as core's own config).
+    '^@stentorosaur/core$': '<rootDir>/../core/src',
+    '^@stentorosaur/core/server$': '<rootDir>/../core/src/server',
+    '^marked$': '<rootDir>/../../node_modules/marked/lib/marked.umd.js',
+  },
+};

--- a/packages/probe/package.json
+++ b/packages/probe/package.json
@@ -1,11 +1,35 @@
 {
   "name": "@stentorosaur/probe",
   "private": true,
-  "version": "0.0.0",
-  "description": "Monitoring engine and I/O for Stentorosaur (ADR-005). Shell package — populated by epic #63; no entry point until the build tooling lands with the first real module.",
+  "version": "0.1.0",
+  "description": "Monitoring engine and I/O for Stentorosaur (ADR-005 §1). All fetching (HTTP checks, GitHub API, git writes) lives here; transforms live in @stentorosaur/core.",
   "license": "MIT",
   "author": "Amiable Development <dev@amiable.dev>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amiable-dev/docusaurus-plugin-stentorosaur.git",
+    "directory": "packages/probe"
+  },
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "prepare": "npm run build",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@stentorosaur/core": "^0.1.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "^30.2.0",
+    "ts-jest": "^29.4.5",
+    "typescript": "^5.0.0"
+  },
   "engines": {
-    "node": ">=20.0"
+    "node": ">=20.19"
   }
 }

--- a/packages/probe/src/check.ts
+++ b/packages/probe/src/check.ts
@@ -13,7 +13,7 @@ import type {CompactReading} from '@stentorosaur/core';
 export interface CheckTarget {
   system: string;
   url: string;
-  method?: 'GET' | 'POST' | 'HEAD';
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
   timeout?: number;
   expectedCodes?: number[];
   maxResponseTime?: number;

--- a/packages/probe/src/check.ts
+++ b/packages/probe/src/check.ts
@@ -26,6 +26,10 @@ export const CHECK_DEFAULTS = {
   maxResponseTime: 30_000,
 };
 
+function sanitizePositive(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && (value as number) > 0 ? (value as number) : fallback;
+}
+
 /** monitor.js parity. */
 export function determineStatus(
   statusCode: number,
@@ -52,9 +56,14 @@ export async function checkEndpoint(
   fetchImpl: typeof fetch = fetch
 ): Promise<CompactReading> {
   const method = target.method ?? CHECK_DEFAULTS.method;
-  const timeout = target.timeout ?? CHECK_DEFAULTS.timeout;
+  // Bounds-check numeric knobs: NaN/zero/negative fall back to defaults
+  // rather than producing instant timeouts or spurious degraded states.
+  const timeout = sanitizePositive(target.timeout, CHECK_DEFAULTS.timeout);
   const expectedCodes = target.expectedCodes ?? CHECK_DEFAULTS.expectedCodes;
-  const maxResponseTime = target.maxResponseTime ?? CHECK_DEFAULTS.maxResponseTime;
+  const maxResponseTime = sanitizePositive(
+    target.maxResponseTime,
+    CHECK_DEFAULTS.maxResponseTime
+  );
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
@@ -70,8 +79,9 @@ export async function checkEndpoint(
       headers: {'user-agent': 'stentorosaur-probe/1.0'},
     });
     statusCode = response.status;
-    // Drain the body so sockets are freed.
-    await response.arrayBuffer().catch(() => undefined);
+    // Discard the body WITHOUT buffering it (a misconfigured target could
+    // return gigabytes); cancel frees the socket immediately.
+    await response.body?.cancel().catch(() => undefined);
   } catch (err) {
     statusCode = 0;
     error = controller.signal.aborted

--- a/packages/probe/src/check.ts
+++ b/packages/probe/src/check.ts
@@ -1,0 +1,138 @@
+/**
+ * HTTP check engine (ADR-005 §1/§6; ticket #69). Native fetch with
+ * AbortController timeouts; status semantics are monitor.js parity:
+ *   code 0 / unexpected → down; slower than maxResponseTime → degraded;
+ *   otherwise up.
+ * Checks run in PARALLEL — per-entity output files (files.ts) make that
+ * safe; the v0.4.10 sequential constraint existed only because of the
+ * legacy shared hot file.
+ */
+
+import type {CompactReading} from '@stentorosaur/core';
+
+export interface CheckTarget {
+  system: string;
+  url: string;
+  method?: 'GET' | 'POST' | 'HEAD';
+  timeout?: number;
+  expectedCodes?: number[];
+  maxResponseTime?: number;
+}
+
+export const CHECK_DEFAULTS = {
+  method: 'GET' as const,
+  timeout: 10_000,
+  expectedCodes: [200],
+  maxResponseTime: 30_000,
+};
+
+/** monitor.js parity. */
+export function determineStatus(
+  statusCode: number,
+  responseTime: number,
+  expectedCodes: number[],
+  maxResponseTime: number
+): 'up' | 'degraded' | 'down' {
+  if (statusCode === 0 || !expectedCodes.includes(statusCode)) {
+    return 'down';
+  }
+  if (responseTime > maxResponseTime) {
+    return 'degraded';
+  }
+  return 'up';
+}
+
+/**
+ * Perform one check. `t` is the reading timestamp (injected by the
+ * caller so a run's readings share a coherent clock).
+ */
+export async function checkEndpoint(
+  target: CheckTarget,
+  t: number,
+  fetchImpl: typeof fetch = fetch
+): Promise<CompactReading> {
+  const method = target.method ?? CHECK_DEFAULTS.method;
+  const timeout = target.timeout ?? CHECK_DEFAULTS.timeout;
+  const expectedCodes = target.expectedCodes ?? CHECK_DEFAULTS.expectedCodes;
+  const maxResponseTime = target.maxResponseTime ?? CHECK_DEFAULTS.maxResponseTime;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  const startedAt = Date.now();
+
+  let statusCode = 0;
+  let error: string | undefined;
+  try {
+    const response = await fetchImpl(target.url, {
+      method,
+      signal: controller.signal,
+      redirect: 'manual', // a 3xx is a real observation, not something to follow
+      headers: {'user-agent': 'stentorosaur-probe/1.0'},
+    });
+    statusCode = response.status;
+    // Drain the body so sockets are freed.
+    await response.arrayBuffer().catch(() => undefined);
+  } catch (err) {
+    statusCode = 0;
+    error = controller.signal.aborted
+      ? 'Timeout'
+      : err instanceof Error
+        ? (err as NodeJS.ErrnoException).cause instanceof Error
+          ? ((err as NodeJS.ErrnoException).cause as Error).message
+          : err.message
+        : String(err);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const responseTime = Date.now() - startedAt;
+  const state = determineStatus(statusCode, responseTime, expectedCodes, maxResponseTime);
+
+  const reading: CompactReading = {
+    t,
+    svc: target.system,
+    state,
+    code: statusCode,
+    lat: responseTime,
+  };
+  if (error) {
+    reading.err = error;
+  } else if (state === 'down') {
+    reading.err = `HTTP ${statusCode}`;
+  }
+  return reading;
+}
+
+export interface RunChecksOptions {
+  /** Max simultaneous checks (default: all targets at once) */
+  concurrency?: number;
+  /** Shared reading timestamp; defaults to run start */
+  now?: number;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Check every target, in parallel up to `concurrency`. Results preserve
+ * target order regardless of completion order.
+ */
+export async function runChecks(
+  targets: CheckTarget[],
+  options: RunChecksOptions = {}
+): Promise<CompactReading[]> {
+  const {concurrency = targets.length || 1, now = Date.now(), fetchImpl} = options;
+  const results = new Array<CompactReading>(targets.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= targets.length) return;
+      results[index] = await checkEndpoint(targets[index], now, fetchImpl);
+    }
+  }
+
+  await Promise.all(
+    Array.from({length: Math.max(1, Math.min(concurrency, targets.length))}, worker)
+  );
+  return results;
+}

--- a/packages/probe/src/check.ts
+++ b/packages/probe/src/check.ts
@@ -119,7 +119,14 @@ export async function runChecks(
   targets: CheckTarget[],
   options: RunChecksOptions = {}
 ): Promise<CompactReading[]> {
-  const {concurrency = targets.length || 1, now = Date.now(), fetchImpl} = options;
+  const {concurrency, now = Date.now(), fetchImpl} = options;
+  // Sanitize: NaN/0/negative concurrency must never yield zero workers
+  // (Array.from with NaN length resolves instantly with no checks run).
+  const requested = Number.isFinite(concurrency) && (concurrency as number) >= 1
+    ? Math.floor(concurrency as number)
+    : targets.length || 1;
+  const workers = Math.max(1, Math.min(requested, targets.length || 1));
+
   const results = new Array<CompactReading>(targets.length);
   let nextIndex = 0;
 
@@ -131,8 +138,6 @@ export async function runChecks(
     }
   }
 
-  await Promise.all(
-    Array.from({length: Math.max(1, Math.min(concurrency, targets.length))}, worker)
-  );
+  await Promise.all(Array.from({length: workers}, worker));
   return results;
 }

--- a/packages/probe/src/files.ts
+++ b/packages/probe/src/files.ts
@@ -66,6 +66,24 @@ export function writeEntityDetail(
   const dir = path.join(rootDir, 'status', 'v1', 'entities');
   fs.mkdirSync(dir, {recursive: true});
   const file = path.join(dir, `${entitySlug(name)}.json`);
+
+  // Write-site collision enforcement (not just the assertUniqueSlugs
+  // pre-flight): never overwrite a DIFFERENT entity's file that happens
+  // to share this slug.
+  if (fs.existsSync(file)) {
+    try {
+      const existing = JSON.parse(fs.readFileSync(file, 'utf8')) as {name?: unknown};
+      if (typeof existing.name === 'string' && existing.name !== name) {
+        throw new Error(
+          `slug collision: '${name}' and '${existing.name}' both map to ${path.basename(file)}`
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && /slug collision/.test(err.message)) throw err;
+      // Unreadable/corrupt existing file: overwriting with valid data is fine.
+    }
+  }
+
   fs.writeFileSync(file, JSON.stringify(detail));
   return file;
 }

--- a/packages/probe/src/files.ts
+++ b/packages/probe/src/files.ts
@@ -9,13 +9,44 @@ import path from 'node:path';
 import {entityDetailSchema} from '@stentorosaur/core';
 import type {CompactReading, EntityDetail} from '@stentorosaur/core';
 
-/** Same slug rules the plugin uses for system file names. */
+/**
+ * Same slug rules the plugin uses for system file names, hardened:
+ * leading/trailing hyphens trimmed, and a deterministic hex fallback for
+ * names that slug to nothing (e.g. all-symbol names) so we never write
+ * a bare '.json'.
+ */
 export function entitySlug(name: string): string {
-  return name
+  const slug = name
     .toLowerCase()
     .replace(/[^a-z0-9\s-]/g, '')
     .replace(/\s+/g, '-')
-    .replace(/-+/g, '-');
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (slug === '') {
+    return `entity-${Buffer.from(name, 'utf8').toString('hex').slice(0, 16)}`;
+  }
+  return slug;
+}
+
+/**
+ * Distinct entity names may collide after slugging ('API v1' and
+ * 'API-v1' both become 'api-v1'), which would silently overwrite files
+ * and break the one-file-per-entity parallel-safety invariant. Callers
+ * run this over the configured entity list before any writes.
+ */
+export function assertUniqueSlugs(names: string[]): void {
+  const bySlug = new Map<string, string[]>();
+  for (const name of names) {
+    const slug = entitySlug(name);
+    bySlug.set(slug, [...(bySlug.get(slug) ?? []), name]);
+  }
+  const collisions = [...bySlug.entries()].filter(([, ns]) => ns.length > 1);
+  if (collisions.length > 0) {
+    throw new Error(
+      'entity names collide after slugging: ' +
+        collisions.map(([slug, ns]) => `${ns.join(' / ')} → ${slug}`).join('; ')
+    );
+  }
 }
 
 /** status/v1/entities/<slug>.json — validated on WRITE (ADR-005 §2). */
@@ -54,16 +85,25 @@ export function appendArchive(rootDir: string, reading: CompactReading): string 
 
 /**
  * Read every entity detail file back (the merged-inputs view a writer
- * regenerates the summary from after a rebase).
+ * regenerates the summary from after a rebase). A malformed file must
+ * not abort the run: it is skipped and reported via onError so one
+ * corrupted input can't take the whole data branch down.
  */
-export function readAllEntityDetails(rootDir: string): EntityDetail[] {
+export function readAllEntityDetails(
+  rootDir: string,
+  onError: (file: string, error: unknown) => void = (file, error) =>
+    console.warn(`[probe] skipping malformed entity detail ${file}:`, error)
+): EntityDetail[] {
   const dir = path.join(rootDir, 'status', 'v1', 'entities');
   if (!fs.existsSync(dir)) return [];
-  return fs
-    .readdirSync(dir)
-    .filter(f => f.endsWith('.json'))
-    .sort()
-    .map(f =>
-      entityDetailSchema.parse(JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')))
-    );
+  const details: EntityDetail[] = [];
+  for (const f of fs.readdirSync(dir).filter(f => f.endsWith('.json')).sort()) {
+    const file = path.join(dir, f);
+    try {
+      details.push(entityDetailSchema.parse(JSON.parse(fs.readFileSync(file, 'utf8'))));
+    } catch (error) {
+      onError(file, error);
+    }
+  }
+  return details;
 }

--- a/packages/probe/src/files.ts
+++ b/packages/probe/src/files.ts
@@ -1,0 +1,69 @@
+/**
+ * status/v1 file I/O for the probe (ticket #69): per-entity detail files
+ * (parallel-safe — one file per entity), ADR-002 JSONL archive appends,
+ * and the recent-readings view used to rebuild summaries.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {entityDetailSchema} from '@stentorosaur/core';
+import type {CompactReading, EntityDetail} from '@stentorosaur/core';
+
+/** Same slug rules the plugin uses for system file names. */
+export function entitySlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+/** status/v1/entities/<slug>.json — validated on WRITE (ADR-005 §2). */
+export function writeEntityDetail(
+  rootDir: string,
+  name: string,
+  readings: CompactReading[],
+  generatedAt: string
+): string {
+  const detail: EntityDetail = {
+    schemaVersion: 1,
+    generatedAt,
+    name,
+    readings,
+  };
+  entityDetailSchema.parse(detail);
+  const dir = path.join(rootDir, 'status', 'v1', 'entities');
+  fs.mkdirSync(dir, {recursive: true});
+  const file = path.join(dir, `${entitySlug(name)}.json`);
+  fs.writeFileSync(file, JSON.stringify(detail));
+  return file;
+}
+
+/** archives/YYYY/MM/history-YYYY-MM-DD.jsonl (ADR-002 layout, unchanged). */
+export function appendArchive(rootDir: string, reading: CompactReading): string {
+  const date = new Date(reading.t);
+  const year = String(date.getUTCFullYear());
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const dir = path.join(rootDir, 'status', 'v1', 'archives', year, month);
+  fs.mkdirSync(dir, {recursive: true});
+  const file = path.join(dir, `history-${year}-${month}-${day}.jsonl`);
+  fs.appendFileSync(file, JSON.stringify(reading) + '\n');
+  return file;
+}
+
+/**
+ * Read every entity detail file back (the merged-inputs view a writer
+ * regenerates the summary from after a rebase).
+ */
+export function readAllEntityDetails(rootDir: string): EntityDetail[] {
+  const dir = path.join(rootDir, 'status', 'v1', 'entities');
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter(f => f.endsWith('.json'))
+    .sort()
+    .map(f =>
+      entityDetailSchema.parse(JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')))
+    );
+}

--- a/packages/probe/src/git-writer.ts
+++ b/packages/probe/src/git-writer.ts
@@ -1,0 +1,115 @@
+/**
+ * Regenerate-and-retry data-branch writer (ADR-005 §5).
+ *
+ * summary.json is a DERIVED file — a pure function of the per-entity
+ * inputs and issue set — so concurrent writers need no locks: on a
+ * non-fast-forward rejection, re-fetch, re-apply OUR OWN inputs on top
+ * of the merged tree, regenerate, and push again. Regeneration after
+ * rebase is always correct because buildSummary is deterministic over
+ * the now-merged inputs.
+ */
+
+import {execFile} from 'node:child_process';
+import {promisify} from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export interface PushWithRetryOptions {
+  /** A git worktree with 'origin' pointing at the data repo */
+  workdir: string;
+  /** Data branch name (e.g. 'status-data') */
+  branch: string;
+  commitMessage: string;
+  /** Write THIS writer's inputs (per-entity readings, archives, raw/) */
+  writeInputs: (workdir: string) => Promise<void>;
+  /** Rebuild every derived file (summary.json, atom) from ALL inputs */
+  regenerate: (workdir: string) => Promise<void>;
+  /** Push attempts before giving up (default 3) */
+  maxRetries?: number;
+  /** Injected for deterministic tests */
+  sleep?: (ms: number) => Promise<void>;
+  jitterMs?: (attempt: number) => number;
+  /** Test seam: runs between commit and push */
+  beforePush?: () => Promise<void>;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+const defaultJitter = (attempt: number) => Math.floor(Math.random() * 500 * attempt);
+
+function isNonFastForward(stderr: string): boolean {
+  return /non-fast-forward|fetch first|\[rejected\]|failed to push/i.test(stderr);
+}
+
+async function git(workdir: string, ...args: string[]): Promise<string> {
+  const {stdout} = await execFileAsync('git', args, {cwd: workdir});
+  return stdout.trim();
+}
+
+async function tryGit(workdir: string, ...args: string[]): Promise<string | null> {
+  try {
+    return await git(workdir, ...args);
+  } catch {
+    return null;
+  }
+}
+
+export async function pushWithRegenerateRetry(
+  options: PushWithRetryOptions
+): Promise<{attempts: number}> {
+  const {
+    workdir,
+    branch,
+    commitMessage,
+    writeInputs,
+    regenerate,
+    maxRetries = 3,
+    sleep = defaultSleep,
+    jitterMs = defaultJitter,
+    beforePush,
+  } = options;
+
+  let lastError = '';
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    // Sync to the latest remote state (branch may not exist yet).
+    await tryGit(workdir, 'fetch', 'origin', branch);
+    const remoteRef = await tryGit(workdir, 'rev-parse', '--verify', `origin/${branch}`);
+    if (remoteRef) {
+      await git(workdir, 'checkout', '-B', branch, `origin/${branch}`);
+    } else {
+      // First-ever write: point (possibly unborn) HEAD at the branch name.
+      await git(workdir, 'symbolic-ref', 'HEAD', `refs/heads/${branch}`);
+    }
+
+    await writeInputs(workdir);
+    await regenerate(workdir);
+
+    await git(workdir, 'add', '-A');
+    const dirty = await git(workdir, 'status', '--porcelain');
+    if (dirty !== '') {
+      await git(workdir, 'commit', '-m', commitMessage);
+    }
+
+    if (beforePush) {
+      await beforePush();
+    }
+
+    try {
+      await git(workdir, 'push', 'origin', `${branch}:${branch}`);
+      return {attempts: attempt};
+    } catch (err) {
+      const stderr =
+        err && typeof err === 'object' && 'stderr' in err
+          ? String((err as {stderr: unknown}).stderr)
+          : String(err);
+      if (!isNonFastForward(stderr)) {
+        throw err;
+      }
+      lastError = stderr;
+      await sleep(jitterMs(attempt));
+    }
+  }
+
+  throw new Error(
+    `data-branch push rejected (non-fast-forward) after ${maxRetries} retries: ${lastError.slice(0, 200)}`
+  );
+}

--- a/packages/probe/src/git-writer.ts
+++ b/packages/probe/src/git-writer.ts
@@ -26,6 +26,9 @@ export interface PushWithRetryOptions {
   regenerate: (workdir: string) => Promise<void>;
   /** Push attempts before giving up (default 3) */
   maxRetries?: number;
+  /** Commit identity — CI runners have no global git config (default: probe bot) */
+  authorName?: string;
+  authorEmail?: string;
   /** Injected for deterministic tests */
   sleep?: (ms: number) => Promise<void>;
   jitterMs?: (attempt: number) => number;
@@ -63,6 +66,8 @@ export async function pushWithRegenerateRetry(
     writeInputs,
     regenerate,
     maxRetries = 3,
+    authorName = 'stentorosaur-probe',
+    authorEmail = 'probe@stentorosaur.invalid',
     sleep = defaultSleep,
     jitterMs = defaultJitter,
     beforePush,
@@ -86,7 +91,13 @@ export async function pushWithRegenerateRetry(
     await git(workdir, 'add', '-A');
     const dirty = await git(workdir, 'status', '--porcelain');
     if (dirty !== '') {
-      await git(workdir, 'commit', '-m', commitMessage);
+      // Inline identity: stateless CI runners have no global git config.
+      await git(
+        workdir,
+        '-c', `user.name=${authorName}`,
+        '-c', `user.email=${authorEmail}`,
+        'commit', '-m', commitMessage
+      );
     }
 
     if (beforePush) {

--- a/packages/probe/src/index.ts
+++ b/packages/probe/src/index.ts
@@ -1,10 +1,9 @@
 /**
  * @stentorosaur/probe — monitoring engine and all I/O (ADR-005 §1).
- *
- * Shell package created by the monorepo scaffold (epic #63, ticket #64).
- * Populated by the probe-engine ticket (#69). All fetching (HTTP checks,
- * GitHub API, git writes) lives here; transformation logic belongs in
- * @stentorosaur/core.
+ * Fetching (HTTP checks, git writes) lives here; transformation logic
+ * belongs in @stentorosaur/core.
  */
 
-export {};
+export * from './check';
+export * from './files';
+export * from './git-writer';

--- a/packages/probe/tsconfig.json
+++ b/packages/probe/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "lib", "**/*.test.ts"]
+}

--- a/packages/probe/tsconfig.json
+++ b/packages/probe/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2022", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "composite": true,
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -13,6 +14,9 @@
     "outDir": "lib",
     "rootDir": "src"
   },
+  "references": [
+    { "path": "../core" }
+  ],
   "include": ["src"],
   "exclude": ["node_modules", "lib", "**/*.test.ts"]
 }


### PR DESCRIPTION
Closes #69

Part of epic #63 (ADR-005), Phase 2.

## Changes

- **`check.ts`**: native-fetch engine (AbortController timeouts, `redirect: 'manual'` so 3xx codes are real observations, UA header) with monitor.js parity semantics: code 0/unexpected → down, over maxResponseTime → degraded, else up. `runChecks` runs a bounded parallel pool that preserves target order.
- **`files.ts`**: per-entity `status/v1/entities/<slug>.json` (schema-validated on WRITE per ADR §2) + ADR-002 JSONL archive appends under `status/v1/archives/`. One file per entity = parallel probing is safe by construction (the v0.4.10 sequential constraint died with the shared hot file).
- **`git-writer.ts`**: `pushWithRegenerateRetry` — the ADR §5 rule as code. Fetch latest → re-apply OWN inputs → regenerate derived files from the MERGED tree → push; non-fast-forward → jittered retry (injected sleep/jitter for deterministic tests); loud error after maxRetries. Handles first-write (unborn branch) via symbolic-ref.

## Test plan (TDD: both suites written before implementation)

- **Real HTTP**: up/down/degraded/timeout/refused/expected-3xx paths; parallel run covers every target exactly once with outcomes identical to sequential.
- **Real git**: bare origin + racing clones — a writer that loses the race retries and converges with BOTH writers' inputs present and the summary regenerated from the merged tree (§5 acceptance); a saboteur pushing before every attempt exhausts maxRetries loudly.
- 20 probe tests green; core 62 and plugin 733 unaffected; typecheck green.

## Notes

- Probe stays `private: true` until the #77 cutover wires publishing (no consumer depends on it yet; the workflow templates in #71 will invoke it).
- The GitHub-issues fetch half of probe I/O lands with #70 (issue-event handler CLI), which composes these writers with core's transforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)