### PR TITLE
feat: status/v1 plugin read path + §4 client fetch protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed the provisional `status-update-v1.yml` workflow template until the published CLI wiring exists
 - Issue syncing now pages through all matching GitHub issues instead of truncating after 1,000 results
+- The status/v1 bridge now preserves canonical entity names for history lookups while still rendering display names
+- Relative status/v1 `dataUrl` values now resolve against the Docusaurus base URL and keep history fetches on the correct path
 
 ## [0.21.10] - 2026-01-29
 

--- a/e2e/run-pipeline.mjs
+++ b/e2e/run-pipeline.mjs
@@ -14,12 +14,14 @@
  */
 import {execFile, execFileSync} from 'node:child_process';
 import fs from 'node:fs';
+import {createRequire} from 'node:module';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {promisify} from 'node:util';
 import {startMockServer} from './mock-server.mjs';
 
 const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SITE = path.join(ROOT, 'fixtures', 'site');
@@ -78,6 +80,31 @@ async function runPipeline() {
     {t: now, svc: 'ghost', state: 'up', code: 200, lat: 43}
   );
   fs.writeFileSync(currentPath, JSON.stringify(readings));
+
+  // Generate status/v1 from the SAME readings via the compiled probe lib
+  // (ticket #72: the v1 read path takes priority in loadContent). Ghost
+  // stays legacy-only: only configured entities get v1 detail files, so
+  // the #62 DOM assertion now guards the v1 pipeline too.
+  const {writeEntityDetail} = require(path.join(ROOT, 'packages', 'probe', 'lib', 'files.js'));
+  const {regenerateDerived} = require(path.join(ROOT, 'packages', 'probe', 'lib', 'regenerate.js'));
+  const generatedAt = new Date().toISOString();
+  const entities = [
+    {name: 'alpha', type: 'system'},
+    {name: 'beta', type: 'system'},
+  ];
+  for (const entity of entities) {
+    const entityReadings = readings
+      .filter(r => r.svc === entity.name)
+      .map(({err, ...rest}) => (typeof err === 'string' ? {...rest, err} : rest));
+    writeEntityDetail(DATA, entity.name, entityReadings, generatedAt);
+  }
+  regenerateDerived(DATA, {
+    generatedAt,
+    generatedBy: 'e2e-pipeline',
+    entities,
+    siteTitle: 'Fixture Status',
+    siteUrl: 'http://127.0.0.1:3999',
+  });
 
   // Build the fixture site with the real plugin (committed-data path).
   execFileSync('npx', ['docusaurus', 'build', SITE, '--out-dir', path.join(SITE, 'build')], {

--- a/e2e/status-page.spec.ts
+++ b/e2e/status-page.spec.ts
@@ -94,3 +94,28 @@ test.describe('postBuild copied the data plane (v0.21.2 regression shape)', () =
     expect(body.length).toBeGreaterThan(0);
   });
 });
+
+test.describe('status/v1 read path (ADR-005 #72)', () => {
+  test('summary.json is served and schema-shaped', async ({request}) => {
+    const res = await request.get('/status-data/status/v1/summary.json');
+    expect(res.ok()).toBe(true);
+    const summary = await res.json();
+    expect(summary.schemaVersion).toBe(1);
+    expect(summary.entities.map((e: {name: string}) => e.name).sort()).toEqual(['alpha', 'beta']);
+    // ghost has readings in legacy current.json but is NOT a configured
+    // entity — it must never enter the v1 contract (#62, v1 edition).
+    expect(JSON.stringify(summary)).not.toContain('ghost');
+  });
+
+  test('the build consumed the v1 path (route data carries the snapshot)', async () => {
+    const statusJson = JSON.parse(
+      fs.readFileSync(path.join(BUILD_DIR, 'status-data', 'status.json'), 'utf8')
+    );
+    expect(statusJson.v1Summary).toBeDefined();
+    expect(statusJson.v1Summary.schemaVersion).toBe(1);
+    expect(statusJson.dataUrl).toBe('/status-data/status/v1/summary.json');
+    // v1 entities drove the items (beta down from the mock's 500s)
+    const beta = statusJson.items.find((i: {name: string}) => i.name === 'beta');
+    expect(beta.status).toBe('down');
+  });
+});

--- a/fixtures/site/docusaurus.config.js
+++ b/fixtures/site/docusaurus.config.js
@@ -36,6 +36,9 @@ const config = {
         useDemoData: false,
         showIncidents: false,
         scheduledMaintenance: {enabled: false},
+        // ADR-005 #72: client-side live refresh from the self-served v1
+        // summary (relative URL — build-time fetch only applies to http(s)).
+        dataUrl: '/status-data/status/v1/summary.json',
       },
     ],
   ],

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/StatusPage.test.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/StatusPage.test.tsx
@@ -10,8 +10,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import {encodeDayRollups} from '@stentorosaur/core';
+import type {StatusSummary} from '@stentorosaur/core';
 import StatusPage from '../src/theme/StatusPage';
 import type { StatusData } from '../src/types';
+import {useStatusSummary} from '../src/v1/useStatusSummary';
 
 // Mock Layout component
 jest.mock('@theme/Layout', () => ({
@@ -22,6 +25,14 @@ jest.mock('@theme/Layout', () => ({
     </div>
   ),
 }));
+
+jest.mock('../src/v1/useStatusSummary', () => ({
+  useStatusSummary: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('StatusPage (default view)', () => {
   const mockStatusData: StatusData = {
@@ -218,5 +229,67 @@ describe('StatusPage (default view)', () => {
 
     // But maintenance should still be visible
     expect(screen.getByText('Scheduled Maintenance')).toBeInTheDocument();
+  });
+
+  it('uses the v1 summary display name but fetches history from the canonical service path', async () => {
+    const summary: StatusSummary = {
+      schemaVersion: 1,
+      generatedAt: '2026-07-12T18:00:00.000Z',
+      generatedBy: 'test',
+      entities: [
+        {
+          name: 'api',
+          displayName: 'API',
+          type: 'system',
+          status: 'up',
+          uptime: {d1: 100, d7: 100, d90: 100},
+          responseTimeMs: {d1: 50},
+          ...encodeDayRollups([{date: '2026-07-12', uptime: 100, avgMs: 50, worst: 'up'}]),
+        },
+      ],
+      incidents: {open: [], recent: []},
+      maintenance: {upcoming: [], inProgress: []},
+    };
+
+    (useStatusSummary as jest.Mock).mockReturnValue({
+      summary,
+      source: 'snapshot',
+      lastError: null,
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        readings: [
+          {
+            t: Date.parse('2026-07-12T18:00:00.000Z'),
+            svc: 'api',
+            state: 'up',
+            code: 200,
+            lat: 50,
+          },
+        ],
+      }),
+    });
+    (global as any).fetch = fetchMock;
+
+    const statusData: StatusData = {
+      items: [],
+      incidents: [],
+      maintenance: [],
+      lastUpdated: '2026-07-12T18:00:00.000Z',
+      showServices: true,
+      showIncidents: true,
+      showPerformanceMetrics: true,
+      useDemoData: false,
+      v1Summary: summary,
+      dataUrl: '/docs/status-data/status/v1/summary.json',
+      repoUrl: 'https://github.com/test/test',
+    };
+
+    render(<StatusPage statusData={statusData} />);
+
+    expect(await screen.findByText('API')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith('/docs/status-data/current.json');
   });
 });

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/integration/minimal-layout.test.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/integration/minimal-layout.test.tsx
@@ -93,18 +93,19 @@ describe('ADR-004: Minimal Layout Integration (#57)', () => {
       const statusData = createStatusData({ statusCardLayout: 'minimal' });
       render(<StatusPage statusData={statusData} />);
 
-      // Should see system names in minimal cards (uses name field)
-      expect(screen.getByText('api')).toBeInTheDocument();
-      expect(screen.getByText('database')).toBeInTheDocument();
-      expect(screen.getByText('cdn')).toBeInTheDocument();
+      // Minimal cards prefer displayName when present (PR #87: StatusPage
+      // now threads displayName through to SystemCard)
+      expect(screen.getByText('API Server')).toBeInTheDocument();
+      expect(screen.getByText('Database')).toBeInTheDocument();
+      expect(screen.getByText('CDN')).toBeInTheDocument();
     });
 
     it('should render detailed layout when statusCardLayout is "detailed"', () => {
       const statusData = createStatusData({ statusCardLayout: 'detailed' });
       render(<StatusPage statusData={statusData} />);
 
-      // Should still see system names (using original StatusBoard)
-      expect(screen.getByText('api')).toBeInTheDocument();
+      // Detailed layout (StatusBoard/StatusItem) also prefers displayName
+      expect(screen.getByText('API Server')).toBeInTheDocument();
     });
   });
 
@@ -156,10 +157,11 @@ describe('ADR-004: Minimal Layout Integration (#57)', () => {
       const statusData = createStatusData({ statusCardLayout: 'minimal' });
       render(<StatusPage statusData={statusData} />);
 
-      // All systems should be rendered (CSS handles display)
-      expect(screen.getByText('api')).toBeInTheDocument();
-      expect(screen.getByText('database')).toBeInTheDocument();
-      expect(screen.getByText('cdn')).toBeInTheDocument();
+      // All systems should be rendered (CSS handles display); minimal
+      // cards render displayName (PR #87)
+      expect(screen.getByText('API Server')).toBeInTheDocument();
+      expect(screen.getByText('Database')).toBeInTheDocument();
+      expect(screen.getByText('CDN')).toBeInTheDocument();
     });
   });
 

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/v1/summary-adapter.test.ts
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/v1/summary-adapter.test.ts
@@ -87,7 +87,8 @@ describe('summaryToStatusData', () => {
   it('maps entities to StatusItems with displayName, status, uptime, latency', () => {
     const data = summaryToStatusData(fixtureSummary(), {repoUrl: 'https://github.com/o/r'});
     expect(data.items).toHaveLength(2);
-    const api = data.items.find(i => i.name === 'API')!;
+    const api = data.items.find(i => i.name === 'api')!;
+    expect(api.displayName).toBe('API');
     expect(api.status).toBe('down');
     expect(api.uptime).toBe('99.95%'); // d90, matching legacy all-time semantics
     expect(api.responseTime).toBe(120);

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/v1/summary-adapter.test.ts
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/v1/summary-adapter.test.ts
@@ -1,0 +1,138 @@
+/**
+ * v1 → legacy adapter tests (ADR-005; epic #63 ticket #72).
+ *
+ * The adapter is the bridge that lets every EXISTING theme component
+ * render the status/v1 contract unchanged: StatusSummary → StatusData.
+ * It dies at the #77 cutover when components consume v1 natively (#73).
+ */
+
+import {encodeDayRollups} from '@stentorosaur/core';
+import type {StatusSummary} from '@stentorosaur/core';
+import {summaryToStatusData} from '../../src/v1/summary-adapter';
+
+const NOW = '2026-07-12T18:00:00.000Z';
+
+function fixtureSummary(): StatusSummary {
+  const days = encodeDayRollups([
+    {date: '2026-07-11', uptime: 100, avgMs: 100, worst: 'up'},
+    {date: '2026-07-12', uptime: 99.5, avgMs: 120, worst: 'degraded'},
+  ]);
+  return {
+    schemaVersion: 1,
+    generatedAt: NOW,
+    generatedBy: 'probe@0.1.0',
+    entities: [
+      {
+        name: 'api',
+        type: 'system',
+        displayName: 'API',
+        status: 'down',
+        uptime: {d1: 99.5, d7: 99.9, d90: 99.95},
+        responseTimeMs: {d1: 120},
+        ...days,
+      },
+      {
+        name: 'onboarding',
+        type: 'process',
+        status: 'up',
+        uptime: {d1: 100, d7: 100, d90: 100},
+        responseTimeMs: {d1: null},
+        ...days,
+      },
+    ],
+    incidents: {
+      open: [
+        {
+          issueNumber: 201,
+          title: 'API outage',
+          severity: 'critical',
+          status: 'open',
+          entities: ['api'],
+          createdAt: '2026-07-12T17:00:00.000Z',
+          closedAt: null,
+          bodyHtml: '<p>Elevated errors.</p>',
+        },
+      ],
+      recent: [
+        {
+          issueNumber: 197,
+          title: 'Past blip',
+          severity: 'minor',
+          status: 'resolved',
+          entities: ['api'],
+          createdAt: '2026-07-10T09:00:00.000Z',
+          closedAt: '2026-07-10T10:00:00.000Z',
+          bodyHtml: '',
+        },
+      ],
+    },
+    maintenance: {
+      upcoming: [
+        {
+          issueNumber: 202,
+          title: 'DB migration',
+          start: '2026-07-14T02:00:00.000Z',
+          end: '2026-07-14T04:00:00.000Z',
+          status: 'upcoming',
+          entities: ['api'],
+          bodyHtml: '<p>Read-only.</p>',
+        },
+      ],
+      inProgress: [],
+    },
+  };
+}
+
+describe('summaryToStatusData', () => {
+  it('maps entities to StatusItems with displayName, status, uptime, latency', () => {
+    const data = summaryToStatusData(fixtureSummary(), {repoUrl: 'https://github.com/o/r'});
+    expect(data.items).toHaveLength(2);
+    const api = data.items.find(i => i.name === 'API')!;
+    expect(api.status).toBe('down');
+    expect(api.uptime).toBe('99.95%'); // d90, matching legacy all-time semantics
+    expect(api.responseTime).toBe(120);
+    expect(api.incidentCount).toBe(1); // one OPEN incident affecting api
+    const onboarding = data.items.find(i => i.name === 'onboarding')!;
+    expect(onboarding.status).toBe('up');
+    expect(onboarding.responseTime).toBeUndefined();
+  });
+
+  it('maps incidents (open + recent) to the legacy shape with issue URLs', () => {
+    const data = summaryToStatusData(fixtureSummary(), {repoUrl: 'https://github.com/o/r'});
+    expect(data.incidents.map(i => i.id)).toEqual([201, 197]);
+    const open = data.incidents[0];
+    expect(open.status).toBe('open');
+    expect(open.severity).toBe('critical');
+    expect(open.url).toBe('https://github.com/o/r/issues/201');
+    expect(open.affectedSystems).toEqual(['API']); // displayName mapping
+    expect(open.body).toBe('<p>Elevated errors.</p>');
+    expect(data.incidents[1].status).toBe('closed');
+    expect(data.incidents[1].closedAt).toBe('2026-07-10T10:00:00.000Z');
+  });
+
+  it('maps maintenance windows to ScheduledMaintenance', () => {
+    const data = summaryToStatusData(fixtureSummary(), {repoUrl: 'https://github.com/o/r'});
+    expect(data.maintenance).toHaveLength(1);
+    expect(data.maintenance[0]).toMatchObject({
+      id: 202,
+      title: 'DB migration',
+      status: 'upcoming',
+      start: '2026-07-14T02:00:00.000Z',
+      affectedSystems: ['API'],
+      description: '<p>Read-only.</p>',
+      url: 'https://github.com/o/r/issues/202',
+    });
+  });
+
+  it('threads lastUpdated from generatedAt and marks v1 provenance', () => {
+    const data = summaryToStatusData(fixtureSummary(), {repoUrl: 'https://github.com/o/r'});
+    expect(data.lastUpdated).toBe(NOW);
+    expect(data.useDemoData).toBe(false);
+  });
+
+  it('is deterministic (no clock reads)', () => {
+    const a = summaryToStatusData(fixtureSummary(), {repoUrl: 'https://github.com/o/r'});
+    const b = summaryToStatusData(fixtureSummary(), {repoUrl: 'https://github.com/o/r'});
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/v1/use-status-summary.test.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/v1/use-status-summary.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * §4 client fetch protocol tests (ADR-005; ticket #72):
+ * 1. snapshot-first render (never blank, no skeleton for initial view)
+ * 2. background ETag fetch; 200→swap, 304→keep, invalid→keep
+ * 3. failure backoff with jitter; 429/403 pauses for Retry-After
+ * 4. refetch on tab focus, timer no faster than the cache TTL
+ * 5. content-type tolerant parsing
+ * @jest-environment jsdom
+ */
+
+import {act, renderHook, waitFor} from '@testing-library/react';
+import {encodeDayRollups} from '@stentorosaur/core';
+import type {StatusSummary} from '@stentorosaur/core';
+import {useStatusSummary} from '../../src/v1/useStatusSummary';
+
+const NOW = '2026-07-12T18:00:00.000Z';
+
+function summary(generatedAt = NOW): StatusSummary {
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    generatedBy: 'test',
+    entities: [
+      {
+        name: 'api',
+        type: 'system',
+        status: 'up',
+        uptime: {d1: 100, d7: 100, d90: 100},
+        responseTimeMs: {d1: 50},
+        ...encodeDayRollups([{date: '2026-07-12', uptime: 100, avgMs: 50, worst: 'up'}]),
+      },
+    ],
+    incidents: {open: [], recent: []},
+    maintenance: {upcoming: [], inProgress: []},
+  };
+}
+
+// jsdom strips Node's Response global; the hook only touches status/ok/
+// headers.get/text, so a minimal stand-in suffices.
+function makeResponse(
+  body: string | null,
+  {status = 200, headers = {} as Record<string, string>} = {}
+) {
+  const map = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {get: (k: string) => map.get(k.toLowerCase()) ?? null},
+    text: async () => body ?? '',
+  };
+}
+function jsonResponse(body: unknown, init: {headers?: Record<string, string>} = {}) {
+  return makeResponse(JSON.stringify(body), {status: 200, headers: init.headers ?? {}});
+}
+
+let fetchMock: jest.Mock;
+beforeEach(() => {
+  jest.useFakeTimers();
+  fetchMock = jest.fn();
+  (global as any).fetch = fetchMock;
+});
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+const snapshot = summary('2026-07-12T17:00:00.000Z');
+
+describe('useStatusSummary (§4 protocol)', () => {
+  it('renders the SSG snapshot immediately, then swaps in fresher live data', async () => {
+    const live = summary('2026-07-12T18:30:00.000Z');
+    fetchMock.mockResolvedValue(jsonResponse(live, {headers: {etag: 'W/"abc"'}}));
+
+    const {result} = renderHook(() =>
+      useStatusSummary({snapshot, dataUrl: 'https://x.example/summary.json'})
+    );
+    // Snapshot-first: data available on the very first render.
+    expect(result.current.summary.generatedAt).toBe('2026-07-12T17:00:00.000Z');
+    expect(result.current.source).toBe('snapshot');
+
+    await waitFor(() => expect(result.current.source).toBe('live'));
+    expect(result.current.summary.generatedAt).toBe('2026-07-12T18:30:00.000Z');
+  });
+
+  it('sends If-None-Match on refetch and keeps state on 304', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(summary(), {headers: {etag: 'W/"v1"'}}))
+      .mockResolvedValueOnce(makeResponse(null, {status: 304}));
+
+    const {result} = renderHook(() =>
+      useStatusSummary({snapshot, dataUrl: 'https://x.example/summary.json', refreshMs: 300_000})
+    );
+    await waitFor(() => expect(result.current.source).toBe('live'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(300_000);
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const secondInit = fetchMock.mock.calls[1][1];
+    expect(secondInit.headers['if-none-match']).toBe('W/"v1"');
+    expect(result.current.summary.generatedAt).toBe(NOW); // kept
+  });
+
+  it('discards schema-invalid responses and keeps the snapshot', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({schemaVersion: 1, nonsense: true}));
+    const {result} = renderHook(() =>
+      useStatusSummary({snapshot, dataUrl: 'https://x.example/summary.json'})
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    // Never hard-fails; snapshot remains.
+    expect(result.current.source).toBe('snapshot');
+    expect(result.current.summary.generatedAt).toBe('2026-07-12T17:00:00.000Z');
+  });
+
+  it('parses text/plain responses as JSON (raw.githubusercontent fallback)', async () => {
+    const live = summary('2026-07-12T19:00:00.000Z');
+    fetchMock.mockResolvedValue(
+      makeResponse(JSON.stringify(live), {status: 200, headers: {'content-type': 'text/plain'}})
+    );
+    const {result} = renderHook(() =>
+      useStatusSummary({snapshot, dataUrl: 'https://x.example/summary.json'})
+    );
+    await waitFor(() => expect(result.current.source).toBe('live'));
+  });
+
+  it('pauses refetching for the Retry-After window on 429', async () => {
+    fetchMock.mockResolvedValue(makeResponse(null, {status: 429, headers: {'retry-after': '120'}}));
+    const {result} = renderHook(() =>
+      useStatusSummary({snapshot, dataUrl: 'https://x.example/summary.json', refreshMs: 30_000})
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // Within the Retry-After window nothing refires, even past refreshMs.
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // After the window, refetching resumes.
+    await act(async () => {
+      jest.advanceTimersByTime(90_000);
+    });
+    await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2));
+    expect(result.current.source).toBe('snapshot'); // still never hard-failed
+  });
+
+  it('backs off with growing delay on network failure', async () => {
+    // Real timers + injected small backoff constants (the fake-timer
+    // rejection path deadlocks React's act scheduling in this setup).
+    jest.useRealTimers();
+    fetchMock.mockRejectedValue(new Error('offline'));
+    const callTimes: number[] = [];
+    fetchMock.mockImplementation(() => {
+      callTimes.push(Date.now());
+      return Promise.reject(new Error('offline'));
+    });
+
+    renderHook(() =>
+      useStatusSummary({
+        snapshot,
+        dataUrl: 'https://x.example/summary.json',
+        refreshMs: 10, // would refire every 10ms if backoff were ignored
+        jitter: () => 0,
+        backoffBaseMs: 120,
+        backoffCapMs: 1_000,
+      })
+    );
+
+    // Wait for three attempts: gaps must follow the DOUBLING backoff
+    // (base 120ms then 240ms), not the 10ms refresh cadence.
+    await waitFor(() => expect(callTimes.length).toBeGreaterThanOrEqual(3), {
+      timeout: 4_000,
+    });
+    const gap1 = callTimes[1] - callTimes[0];
+    const gap2 = callTimes[2] - callTimes[1];
+    expect(gap1).toBeGreaterThanOrEqual(100);
+    expect(gap2).toBeGreaterThanOrEqual(200);
+    expect(gap2).toBeGreaterThan(gap1);
+  });
+
+  it('refetches on window focus', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(summary(), {headers: {etag: 'W/"v1"'}}));
+    renderHook(() =>
+      useStatusSummary({snapshot, dataUrl: 'https://x.example/summary.json', refreshMs: 600_000})
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('does nothing without a dataUrl (pure snapshot mode, e.g. private repos)', () => {
+    const {result} = renderHook(() => useStatusSummary({snapshot}));
+    expect(result.current.source).toBe('snapshot');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/v1/use-status-summary.test.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/v1/use-status-summary.test.tsx
@@ -143,6 +143,32 @@ describe('useStatusSummary (§4 protocol)', () => {
     expect(result.current.source).toBe('snapshot'); // still never hard-failed
   });
 
+  it('never polls faster than the cache TTL even if refreshMs is smaller', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(summary(), {headers: {etag: 'W/"v1"'}}))
+      .mockResolvedValueOnce(makeResponse(null, {status: 304}));
+
+    renderHook(() =>
+      useStatusSummary({
+        snapshot,
+        dataUrl: 'https://x.example/summary.json',
+        refreshMs: 1_000,
+        jitter: () => 0,
+      })
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      jest.advanceTimersByTime(300_000 - 1);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
   it('backs off with growing delay on network failure', async () => {
     // Real timers + injected small backoff constants (the fake-timer
     // rejection path deadlocks React's act scheduling in this setup).

--- a/packages/docusaurus-plugin-stentorosaur/src/index.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/index.ts
@@ -14,10 +14,13 @@ import {
   groupReadingsBySystem,
 } from '@stentorosaur/core';
 import type {CompactReading} from '@stentorosaur/core';
+import {parseSummary} from '@stentorosaur/core';
+import type {StatusSummary} from '@stentorosaur/core';
 import type {LoadContext, Plugin} from '@docusaurus/types';
 import type {PluginOptions, StatusData, StatusItem, SystemStatusFile, StatusIncident, ScheduledMaintenance, Entity} from './types';
 import {GitHubStatusService} from './github-service';
 import {getDemoStatusData, getDemoSystemFiles, getDemoCurrentJson} from './demo-data';
+import {summaryToStatusData} from './v1/summary-adapter';
 
 export {validateOptions} from './options';
 
@@ -387,6 +390,62 @@ export default async function pluginStatus(
     },
 
     async loadContent() {
+      // ── status/v1 read path (ADR-005, ticket #72) ─────────────────
+      // Takes priority over EVERY legacy path. Sources, in order:
+      // an options.dataUrl endpoint fetched at build time, else a local
+      // status/v1/summary.json under dataPath (e.g. the data branch
+      // checked out in CI, or a fixture). Failures fall through to the
+      // legacy paths with a warning — never a broken build.
+      {
+        let v1Summary: StatusSummary | null = null;
+        const localV1 = path.join(siteDir, dataPath, 'status', 'v1', 'summary.json');
+        if (options.dataUrl && /^https?:\/\//.test(options.dataUrl)) {
+          try {
+            const response = await fetch(options.dataUrl, {
+              headers: {accept: 'application/json'},
+            });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            v1Summary = parseSummary(JSON.parse(await response.text()));
+            console.log('[docusaurus-plugin-stentorosaur] Loaded status/v1 summary from dataUrl');
+          } catch (error) {
+            console.warn(
+              '[docusaurus-plugin-stentorosaur] dataUrl fetch failed, trying local/legacy data:',
+              error instanceof Error ? error.message : String(error)
+            );
+          }
+        }
+        if (!v1Summary && (await fs.pathExists(localV1))) {
+          try {
+            v1Summary = parseSummary(await fs.readJson(localV1));
+            console.log('[docusaurus-plugin-stentorosaur] Loaded local status/v1 summary');
+          } catch (error) {
+            console.warn(
+              '[docusaurus-plugin-stentorosaur] Invalid local status/v1 summary, falling back:',
+              error instanceof Error ? error.message : String(error)
+            );
+          }
+        }
+
+        if (v1Summary) {
+          const repoUrl = `https://github.com/${owner}/${repo}`;
+          const statusData: StatusData = {
+            ...summaryToStatusData(v1Summary, {repoUrl}),
+            showServices,
+            showIncidents,
+            showPerformanceMetrics,
+            statusCardLayout: options.statusCardLayout,
+            pluginVersion: PLUGIN_VERSION,
+            v1Summary,
+            ...(options.dataUrl ? {dataUrl: options.dataUrl} : {}),
+            repoUrl,
+          };
+          await fs.ensureDir(statusDataDir);
+          await fs.writeJson(statusDataPath, statusData, {spaces: 2});
+          return statusData;
+        }
+      }
+      // ── legacy read paths below (deleted at the #77 cutover) ───────
+
       let items: StatusItem[] = [];
       let incidents: StatusIncident[] = [];
       let maintenance: ScheduledMaintenance[] = [];
@@ -849,6 +908,14 @@ export default async function pluginStatus(
           sourceMaintenance,
           path.join(buildStatusDir, 'maintenance.json')
         );
+      }
+
+      // Copy the status/v1 tree if present (ADR-005 #72) so a site can
+      // self-serve summary.json (site-relative dataUrl) without Pages.
+      const sourceV1 = path.join(sourceDataDir, 'status', 'v1');
+      if (await fs.pathExists(sourceV1)) {
+        console.log('[docusaurus-plugin-stentorosaur] Copying status/v1 data');
+        await fs.copy(sourceV1, path.join(buildStatusDir, 'status', 'v1'));
       }
 
       // If using demo data, write demo system files with historical data for charts

--- a/packages/docusaurus-plugin-stentorosaur/src/index.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/index.ts
@@ -399,6 +399,11 @@ export default async function pluginStatus(
       {
         let v1Summary: StatusSummary | null = null;
         const localV1 = path.join(siteDir, dataPath, 'status', 'v1', 'summary.json');
+        const runtimeDataUrl = options.dataUrl
+          ? (/^https?:\/\//.test(options.dataUrl)
+            ? options.dataUrl
+            : normalizeUrl([siteConfig.baseUrl, options.dataUrl]))
+          : undefined;
         if (options.dataUrl && /^https?:\/\//.test(options.dataUrl)) {
           try {
             const response = await fetch(options.dataUrl, {
@@ -433,10 +438,11 @@ export default async function pluginStatus(
             showServices,
             showIncidents,
             showPerformanceMetrics,
+            fetchUrl: options.fetchUrl,
             statusCardLayout: options.statusCardLayout,
             pluginVersion: PLUGIN_VERSION,
             v1Summary,
-            ...(options.dataUrl ? {dataUrl: options.dataUrl} : {}),
+            ...(runtimeDataUrl ? {dataUrl: runtimeDataUrl} : {}),
             repoUrl,
           };
           await fs.ensureDir(statusDataDir);

--- a/packages/docusaurus-plugin-stentorosaur/src/options.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/options.ts
@@ -270,6 +270,7 @@ const pluginOptionsSchema = Joi.object<PluginOptions>({
   statusLabel: Joi.string().default(DEFAULT_OPTIONS.statusLabel),
   entities: Joi.array().items(entitySchema).default(DEFAULT_OPTIONS.entities),
   entitiesSource: Joi.string().valid('config', 'monitorrc', 'hybrid').default('config'),
+  dataUrl: Joi.string().uri({allowRelative: true}),
   labelScheme: labelSchemeSchema.default(DEFAULT_OPTIONS.labelScheme),
   token: Joi.string(),
   updateInterval: Joi.number().min(1).default(DEFAULT_OPTIONS.updateInterval),

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/StatusItem/index.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/StatusItem/index.tsx
@@ -60,6 +60,7 @@ export default function StatusItem({
   heatmapDays,
 }: Props): JSX.Element {
   const config = statusConfig[item.status];
+  const label = item.displayName || item.name;
 
   // Determine days to show: use prop if provided, otherwise 90 if dataBaseUrl, else 14
   const daysToShow = heatmapDays ?? (dataBaseUrl ? 90 : 14);
@@ -142,7 +143,7 @@ export default function StatusItem({
           >
             {config.icon}
           </span>
-          <h3>{item.name}</h3>
+          <h3>{label}</h3>
         </div>
         <div className={styles.statusLabel} style={{color: config.color}}>
           {config.label}

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
@@ -14,6 +14,9 @@ import PerformanceMetrics from '../PerformanceMetrics';
 import { SystemCard, SystemCardDetails, SystemCardUptimeBar } from '../SystemCard';
 import { StatusDataProvider } from '../../context/StatusDataProvider';
 import type {StatusData, SystemStatusFile, DataSource} from '../../types';
+import {parseSummary} from '@stentorosaur/core';
+import {useStatusSummary} from '../../v1/useStatusSummary';
+import {summaryToStatusData} from '../../v1/summary-adapter';
 import { buildFetchUrl } from '../../data-source-resolver.client';
 import styles from './styles.module.css';
 
@@ -21,7 +24,40 @@ export interface Props {
   readonly statusData: StatusData;
 }
 
+/**
+ * status/v1 live bridge (ADR-005 par-4, ticket #72): snapshot-first render
+ * via useStatusSummary, adapted to the legacy shape the inner page
+ * consumes. The adapted data carries no v1Summary field, so the inner
+ * render takes the normal path.
+ */
+function V1LiveStatusPage({statusData}: Props): JSX.Element {
+  const snapshot = React.useMemo(
+    () => parseSummary(statusData.v1Summary),
+    [statusData.v1Summary]
+  );
+  const {summary} = useStatusSummary({snapshot, dataUrl: statusData.dataUrl});
+  const adapted = React.useMemo<StatusData>(
+    () => ({
+      ...summaryToStatusData(summary, {repoUrl: statusData.repoUrl ?? ''}),
+      showServices: statusData.showServices,
+      showIncidents: statusData.showIncidents,
+      showPerformanceMetrics: statusData.showPerformanceMetrics,
+      statusCardLayout: statusData.statusCardLayout,
+      pluginVersion: statusData.pluginVersion,
+    }),
+    [summary, statusData]
+  );
+  return <StatusPageInner statusData={adapted} />;
+}
+
 export default function StatusPage({statusData}: Props): JSX.Element {
+  if (statusData?.v1Summary) {
+    return <V1LiveStatusPage statusData={statusData} />;
+  }
+  return <StatusPageInner statusData={statusData} />;
+}
+
+function StatusPageInner({statusData}: Props): JSX.Element {
   const {
     items = [],
     incidents = [],

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
@@ -24,6 +24,15 @@ export interface Props {
   readonly statusData: StatusData;
 }
 
+const V1_SUMMARY_SUFFIX = '/status/v1/summary.json';
+
+function deriveV1HistoryBaseUrl(dataUrl?: string): string | undefined {
+  if (!dataUrl || !dataUrl.endsWith(V1_SUMMARY_SUFFIX)) {
+    return undefined;
+  }
+  return dataUrl.slice(0, -V1_SUMMARY_SUFFIX.length);
+}
+
 /**
  * status/v1 live bridge (ADR-005 par-4, ticket #72): snapshot-first render
  * via useStatusSummary, adapted to the legacy shape the inner page
@@ -36,16 +45,22 @@ function V1LiveStatusPage({statusData}: Props): JSX.Element {
     [statusData.v1Summary]
   );
   const {summary} = useStatusSummary({snapshot, dataUrl: statusData.dataUrl});
+  const fetchUrl = React.useMemo(
+    () => statusData.fetchUrl ?? deriveV1HistoryBaseUrl(statusData.dataUrl),
+    [statusData.dataUrl, statusData.fetchUrl]
+  );
   const adapted = React.useMemo<StatusData>(
     () => ({
       ...summaryToStatusData(summary, {repoUrl: statusData.repoUrl ?? ''}),
       showServices: statusData.showServices,
       showIncidents: statusData.showIncidents,
       showPerformanceMetrics: statusData.showPerformanceMetrics,
+      fetchUrl,
+      dataSource: statusData.dataSource,
       statusCardLayout: statusData.statusCardLayout,
       pluginVersion: statusData.pluginVersion,
     }),
-    [summary, statusData]
+    [fetchUrl, summary, statusData]
   );
   return <StatusPageInner statusData={adapted} />;
 }
@@ -285,6 +300,7 @@ function StatusPageInner({statusData}: Props): JSX.Element {
               <SystemCard
                 key={item.name}
                 name={item.name}
+                displayName={item.displayName}
                 status={item.status}
                 expandable
                 onExpandChange={showPerformanceMetrics && hasSystemData(item.name)

--- a/packages/docusaurus-plugin-stentorosaur/src/types.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/types.ts
@@ -120,6 +120,7 @@ export interface SystemStatusFile {
 
 export interface StatusItem {
   name: string;
+  displayName?: string;
   description?: string;
   status: StatusItemStatus;
   lastChecked?: string;

--- a/packages/docusaurus-plugin-stentorosaur/src/types.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/types.ts
@@ -550,6 +550,14 @@ export interface PluginOptions {
    * @see docs/adrs/ADR-001-configurable-data-fetching-strategies.md
    */
   dataSource?: DataSource | string;
+
+  /**
+   * status/v1 summary.json endpoint (ADR-005 §3/§4). When set (or when a
+   * local status/v1/summary.json exists under dataPath), the v1 read
+   * path takes priority over every legacy data path. PUBLIC endpoints
+   * only — private repos use the build-time snapshot (§9).
+   */
+  dataUrl?: string;
 }
 
 export interface StatusData {
@@ -587,6 +595,15 @@ export interface StatusData {
    * components never need a generated version module (ADR-005 §11)
    */
   pluginVersion?: string;
+
+  /**
+   * status/v1 mode (ADR-005): the raw summary snapshot embedded at build
+   * time (SSG-first render, §4) plus the endpoint for live refresh and
+   * the repo URL the adapter uses for issue links.
+   */
+  v1Summary?: unknown;
+  dataUrl?: string;
+  repoUrl?: string;
 }
 
 export interface UptimeStatusSection {

--- a/packages/docusaurus-plugin-stentorosaur/src/v1/summary-adapter.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/v1/summary-adapter.ts
@@ -1,0 +1,110 @@
+/**
+ * status/v1 → legacy StatusData adapter (ADR-005; epic #63 ticket #72).
+ *
+ * The bridge that lets every existing theme component render the v1
+ * contract unchanged: loadContent parses summary.json and adapts it to
+ * the shape the components already consume. Pure and deterministic.
+ * Dies at the #77 cutover when components consume v1 natively (#73).
+ */
+
+import type {StatusSummary, StatusIncidentV1, SummaryEntity} from '@stentorosaur/core';
+import type {
+  ScheduledMaintenance,
+  StatusData,
+  StatusIncident,
+  StatusItem,
+} from '../types';
+
+export interface AdapterOptions {
+  /** e.g. https://github.com/owner/repo — used to reconstruct issue URLs */
+  repoUrl: string;
+}
+
+function displayNameOf(entities: SummaryEntity[], name: string): string {
+  const entity = entities.find(e => e.name === name);
+  return entity?.displayName || name;
+}
+
+function toLegacyIncident(
+  incident: StatusIncidentV1,
+  summary: StatusSummary,
+  repoUrl: string
+): StatusIncident {
+  return {
+    id: incident.issueNumber,
+    title: incident.title,
+    status: incident.status === 'resolved' ? 'closed' : 'open',
+    severity: incident.severity,
+    createdAt: incident.createdAt,
+    updatedAt: incident.closedAt ?? incident.createdAt,
+    ...(incident.closedAt ? {closedAt: incident.closedAt} : {}),
+    url: `${repoUrl}/issues/${incident.issueNumber}`,
+    // v1 bodies are sanitized HTML rendered at write time; the legacy
+    // markdown pipeline re-sanitizes on render (harmless double guard
+    // during the bridge period).
+    body: incident.bodyHtml,
+    labels: [incident.severity, ...incident.entities],
+    affectedSystems: incident.entities.map(name =>
+      displayNameOf(summary.entities, name)
+    ),
+  };
+}
+
+export function summaryToStatusData(
+  summary: StatusSummary,
+  options: AdapterOptions
+): StatusData {
+  const {repoUrl} = options;
+
+  const openByEntity = new Map<string, number>();
+  for (const incident of summary.incidents.open) {
+    for (const entity of incident.entities) {
+      openByEntity.set(entity, (openByEntity.get(entity) ?? 0) + 1);
+    }
+  }
+
+  const items: StatusItem[] = summary.entities.map(entity => ({
+    name: entity.displayName || entity.name,
+    status: entity.status,
+    lastChecked: summary.generatedAt,
+    ...(entity.responseTimeMs.d1 !== null
+      ? {responseTime: entity.responseTimeMs.d1}
+      : {}),
+    uptime: `${entity.uptime.d90.toFixed(2)}%`,
+    incidentCount: openByEntity.get(entity.name) ?? 0,
+  }));
+
+  const incidents: StatusIncident[] = [
+    ...summary.incidents.open,
+    ...summary.incidents.recent,
+  ].map(incident => toLegacyIncident(incident, summary, repoUrl));
+
+  const maintenance: ScheduledMaintenance[] = [
+    ...summary.maintenance.inProgress,
+    ...summary.maintenance.upcoming,
+  ].map(window => ({
+    id: window.issueNumber,
+    title: window.title,
+    start: window.start,
+    end: window.end,
+    status: window.status,
+    affectedSystems: window.entities.map(name =>
+      displayNameOf(summary.entities, name)
+    ),
+    description: window.bodyHtml,
+    comments: [],
+    url: `${repoUrl}/issues/${window.issueNumber}`,
+    createdAt: window.start,
+  }));
+
+  return {
+    items,
+    incidents,
+    maintenance,
+    lastUpdated: summary.generatedAt,
+    showServices: true,
+    showIncidents: true,
+    showPerformanceMetrics: true,
+    useDemoData: false,
+  };
+}

--- a/packages/docusaurus-plugin-stentorosaur/src/v1/summary-adapter.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/v1/summary-adapter.ts
@@ -64,7 +64,8 @@ export function summaryToStatusData(
   }
 
   const items: StatusItem[] = summary.entities.map(entity => ({
-    name: entity.displayName || entity.name,
+    name: entity.name,
+    ...(entity.displayName ? {displayName: entity.displayName} : {}),
     status: entity.status,
     lastChecked: summary.generatedAt,
     ...(entity.responseTimeMs.d1 !== null

--- a/packages/docusaurus-plugin-stentorosaur/src/v1/useStatusSummary.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/v1/useStatusSummary.ts
@@ -1,0 +1,162 @@
+/**
+ * THE client data hook (ADR-005 §4; epic #63 ticket #72).
+ *
+ * Implements the mandated fetch protocol:
+ *  1. Render immediately from the SSG snapshot (stale-while-revalidate) —
+ *     the page is never blank and never shows a loading skeleton.
+ *  2. Background fetch with If-None-Match; 200 → validate + swap,
+ *     304/invalid → keep current state.
+ *  3. Failures: exponential backoff with full jitter (base 30s, cap
+ *     15min); 429/403 pauses for the Retry-After window. The status page
+ *     never hard-fails because the data plane is unreachable.
+ *  4. Refetch on tab focus and on a timer no faster than the serving
+ *     cache TTL (default 5 min).
+ *  5. Responses parsed as JSON regardless of Content-Type (the
+ *     raw.githubusercontent fallback serves text/plain).
+ *
+ * No dataUrl (e.g. private repos, ADR-005 §9) → pure snapshot mode.
+ */
+
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {parseSummary} from '@stentorosaur/core';
+import type {StatusSummary} from '@stentorosaur/core';
+
+const BACKOFF_BASE_MS = 30_000;
+const BACKOFF_CAP_MS = 15 * 60_000;
+const DEFAULT_REFRESH_MS = 5 * 60_000; // never poll faster than the CDN TTL
+
+export interface UseStatusSummaryOptions {
+  /** Build-time snapshot embedded by loadContent — always present */
+  snapshot: StatusSummary;
+  /** Public summary.json endpoint; absent → snapshot-only mode */
+  dataUrl?: string;
+  /** Refresh cadence (min-clamped to the default TTL) */
+  refreshMs?: number;
+  /** Injected for deterministic tests */
+  jitter?: () => number;
+  /** Test seams — production always uses the §4 constants */
+  backoffBaseMs?: number;
+  backoffCapMs?: number;
+}
+
+export interface UseStatusSummaryResult {
+  summary: StatusSummary;
+  source: 'snapshot' | 'live';
+  /** Non-fatal diagnostics for debugging panels; never blocks rendering */
+  lastError: string | null;
+}
+
+export function useStatusSummary(
+  options: UseStatusSummaryOptions
+): UseStatusSummaryResult {
+  const {snapshot, dataUrl, jitter} = options;
+  const refreshMs = Math.max(options.refreshMs ?? DEFAULT_REFRESH_MS, 1);
+  const backoffBaseMs = options.backoffBaseMs ?? BACKOFF_BASE_MS;
+  const backoffCapMs = options.backoffCapMs ?? BACKOFF_CAP_MS;
+
+  const [state, setState] = useState<UseStatusSummaryResult>({
+    summary: snapshot,
+    source: 'snapshot',
+    lastError: null,
+  });
+
+  const etagRef = useRef<string | null>(null);
+  const failuresRef = useRef(0);
+  const pausedUntilRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeRef = useRef(true);
+
+  const jitterMs = useCallback(
+    () => (jitter ? jitter() : Math.random() * 1000),
+    [jitter]
+  );
+
+  // Latest-ref pattern: callers (timers, focus handler, effect) always
+  // invoke the CURRENT refetch without appearing in effect deps — an
+  // inline jitter/option prop must never cause an effect re-run that
+  // fires an extra fetch (that would defeat the backoff).
+  const refetchRef = useRef<() => Promise<void>>(async () => {});
+
+  const scheduleNext = useCallback((delay: number) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => void refetchRef.current(), delay);
+  }, []);
+
+  const refetch = useCallback(async (): Promise<void> => {
+    if (!dataUrl || !activeRef.current) return;
+    if (Date.now() < pausedUntilRef.current) {
+      scheduleNext(pausedUntilRef.current - Date.now() + jitterMs());
+      return;
+    }
+
+    try {
+      const headers: Record<string, string> = {accept: 'application/json'};
+      if (etagRef.current) headers['if-none-match'] = etagRef.current;
+      const response = await fetch(dataUrl, {headers});
+
+      if (response.status === 304) {
+        failuresRef.current = 0;
+        scheduleNext(refreshMs + jitterMs());
+        return;
+      }
+      if (response.status === 429 || response.status === 403) {
+        const retryAfter = Number(response.headers.get('retry-after'));
+        const pauseMs = Number.isFinite(retryAfter) && retryAfter > 0
+          ? retryAfter * 1000
+          : backoffCapMs;
+        pausedUntilRef.current = Date.now() + pauseMs;
+        setState(s => ({...s, lastError: `rate limited (HTTP ${response.status})`}));
+        scheduleNext(pauseMs + jitterMs());
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      // Content-type tolerant: parse the text as JSON regardless.
+      const text = await response.text();
+      const parsed = parseSummary(JSON.parse(text));
+      etagRef.current = response.headers.get('etag');
+      failuresRef.current = 0;
+      if (activeRef.current) {
+        setState({summary: parsed, source: 'live', lastError: null});
+      }
+      scheduleNext(refreshMs + jitterMs());
+    } catch (error) {
+      // Validation failures and network errors are equivalent here: keep
+      // the current (snapshot or last-good) state and back off.
+      failuresRef.current += 1;
+      const backoff = Math.min(
+        backoffBaseMs * 2 ** (failuresRef.current - 1),
+        backoffCapMs
+      );
+      if (activeRef.current) {
+        setState(s => ({
+          ...s,
+          lastError: error instanceof Error ? error.message : String(error),
+        }));
+      }
+      scheduleNext(backoff + jitterMs());
+    }
+  }, [dataUrl, refreshMs, jitterMs, scheduleNext, backoffBaseMs, backoffCapMs]);
+
+  refetchRef.current = refetch;
+
+  useEffect(() => {
+    if (!dataUrl) return undefined;
+    activeRef.current = true;
+    void refetchRef.current();
+
+    const onFocus = () => {
+      if (Date.now() >= pausedUntilRef.current) void refetchRef.current();
+    };
+    window.addEventListener('focus', onFocus);
+    return () => {
+      activeRef.current = false;
+      window.removeEventListener('focus', onFocus);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [dataUrl]);
+
+  return state;
+}

--- a/packages/docusaurus-plugin-stentorosaur/src/v1/useStatusSummary.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/v1/useStatusSummary.ts
@@ -50,7 +50,7 @@ export function useStatusSummary(
   options: UseStatusSummaryOptions
 ): UseStatusSummaryResult {
   const {snapshot, dataUrl, jitter} = options;
-  const refreshMs = Math.max(options.refreshMs ?? DEFAULT_REFRESH_MS, 1);
+  const refreshMs = Math.max(options.refreshMs ?? DEFAULT_REFRESH_MS, DEFAULT_REFRESH_MS);
   const backoffBaseMs = options.backoffBaseMs ?? BACKOFF_BASE_MS;
   const backoffCapMs = options.backoffCapMs ?? BACKOFF_CAP_MS;
 


### PR DESCRIPTION
Closes #72

Part of epic #63 (ADR-005), Phase 2 — the plugin-side heart of the cutover.

## Changes

- **v1-first `loadContent`**: `options.dataUrl` (build-time fetch, absolute http(s) only per §9) or a local `status/v1/summary.json` under `dataPath` → `parseSummary` → **v1→legacy adapter** → every existing component renders the new contract unchanged. Any failure falls through to the legacy paths with a warning — never a broken build.
- **`useStatusSummary`** — the §4 protocol as one hook: snapshot-first render (the loading-skeleton bug family is structurally impossible), `If-None-Match`/304, exponential backoff (30s base → 15min cap, full jitter), 429/403 honors `Retry-After`, refetch on focus, timer clamped to the cache TTL, JSON-parse regardless of content-type (raw.githubusercontent fallback). **TDD paid off**: the backoff test exposed that an inline option prop re-fired the fetch effect after every state update, silently defeating backoff — fixed with a latest-ref pattern and pinned by the test.
- **StatusPage live bridge**: `v1Summary` present → hook + adapter → recurse into the untouched legacy renderer (no component rewrites; those are #73).
- **`summaryToStatusData`**: pure, deterministic, 5 unit tests. Bridge code — dies at #77.
- **e2e now exercises BOTH worlds**: the pipeline generates `status/v1` from the same mock readings via the compiled probe lib; new specs assert the served summary is schema-shaped, ghost never enters the v1 contract (#62, v1 edition), and the route data proves the build consumed the v1 path. All 10 legacy assertions still green.

## Test plan

- 13 new unit tests (5 adapter + 8 hook incl. fake-timer 304/429/backoff/focus and a real-timer gap-measurement backoff test)
- e2e 12/12; plugin suite 746; core 63; probe 42; typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)