### PR TITLE
feat: stentorosaur migrate — one-time historical data migration (#75)

### DIFF
--- a/packages/probe/__tests__/migrate.test.ts
+++ b/packages/probe/__tests__/migrate.test.ts
@@ -1,0 +1,443 @@
+/**
+ * One-time historical data migration tests (ADR-005 Migration Phase 1,
+ * council condition 6; epic #63 ticket #75).
+ *
+ * The invariant under test: existing users' 90-day history is IDENTICAL
+ * pre/post migration — day-level uptime and average latency from the
+ * migrated status/v1 archives must match what the legacy files record,
+ * across three fixture generations (v0.4 three-file, v0.17
+ * daily-summary, v0.21 current) plus the pre-three-file systems/*.json
+ * shape.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import {buildDailyRollups} from '@stentorosaur/core/server';
+import {parseSummary} from '@stentorosaur/core';
+import type {CompactReading} from '@stentorosaur/core';
+import {collectLegacyData, migrateHistoricalData, planMigration} from '../src/migrate';
+import {readArchiveReadings} from '../src/archives';
+
+let legacy: string;
+let target: string;
+beforeEach(() => {
+  legacy = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-legacy-'));
+  target = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-target-'));
+});
+afterEach(() => {
+  fs.rmSync(legacy, {recursive: true, force: true});
+  fs.rmSync(target, {recursive: true, force: true});
+});
+
+const NOW = Date.parse('2026-07-13T12:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+const GENERATED_AT = new Date(NOW).toISOString();
+const ENTITIES = [
+  {name: 'api', type: 'system' as const},
+  {name: 'web', type: 'system' as const},
+];
+
+function utcDate(ms: number): string {
+  return new Date(ms).toISOString().split('T')[0];
+}
+
+/** Deterministic synthetic reading generator — NO Math.random. */
+function makeReadings(svc: string, dayStartMs: number, count: number, failEvery: number): CompactReading[] {
+  const readings: CompactReading[] = [];
+  for (let i = 0; i < count; i++) {
+    const failed = failEvery > 0 && i % failEvery === 0;
+    readings.push({
+      t: dayStartMs + i * Math.floor(DAY_MS / count),
+      svc,
+      state: failed ? 'down' : 'up',
+      code: failed ? 500 : 200,
+      lat: failed ? 0 : 40 + ((i * 7) % 25),
+    });
+  }
+  return readings;
+}
+
+function writeLegacyArchiveDay(dir: string, dateMs: number, readings: CompactReading[], gzip = false): void {
+  const date = new Date(dateMs);
+  const y = String(date.getUTCFullYear());
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  const archDir = path.join(dir, 'archives', y, m);
+  fs.mkdirSync(archDir, {recursive: true});
+  const body = readings.map(r => JSON.stringify(r)).join('\n') + '\n';
+  const file = path.join(archDir, `history-${y}-${m}-${d}.jsonl`);
+  if (gzip) {
+    fs.writeFileSync(`${file}.gz`, zlib.gzipSync(body));
+  } else {
+    fs.writeFileSync(file, body);
+  }
+}
+
+/**
+ * Build a v0.21-generation legacy fixture: 90 days of archives (gzipped
+ * except the last 3), current.json overlapping the last 14 days, and a
+ * daily-summary.json derived from the same readings.
+ */
+function buildV021Fixture(dir: string): Map<string, CompactReading[]> {
+  const bySvcDay = new Map<string, CompactReading[]>();
+  const current: CompactReading[] = [];
+  for (let d = 89; d >= 0; d--) {
+    const dayStart = NOW - d * DAY_MS - (NOW % DAY_MS);
+    const day: CompactReading[] = [];
+    for (const svc of ['api', 'web']) {
+      const readings = makeReadings(svc, dayStart, 24, svc === 'api' && d % 10 === 3 ? 6 : 0);
+      day.push(...readings);
+      bySvcDay.set(`${svc}|${utcDate(dayStart)}`, readings);
+      if (d < 14) current.push(...readings);
+    }
+    writeLegacyArchiveDay(dir, dayStart, day, d > 2);
+  }
+  fs.writeFileSync(path.join(dir, 'current.json'), JSON.stringify(current));
+  return bySvcDay;
+}
+
+describe('golden zero-data-loss migration (v0.21 fixture)', () => {
+  it('day-level uptime and latency are identical pre/post for 90 days', () => {
+    buildV021Fixture(legacy);
+    const legacyRollups = buildDailyRollups(readLegacyForGolden(legacy));
+
+    const report = migrateHistoricalData({
+      legacyDir: legacy,
+      targetDir: target,
+      entities: ENTITIES,
+      generatedAt: GENERATED_AT,
+    });
+    expect(report.corruptLines).toBe(0);
+
+    const migrated = buildDailyRollups(readArchiveReadings(target, 90, NOW));
+    for (const svc of ['api', 'web']) {
+      expect(migrated[svc]).toHaveLength(legacyRollups[svc].length);
+      expect(migrated[svc]).toEqual(legacyRollups[svc]);
+    }
+  });
+
+  it('writes entity details for configured entities and a valid summary', () => {
+    buildV021Fixture(legacy);
+    migrateHistoricalData({
+      legacyDir: legacy,
+      targetDir: target,
+      entities: ENTITIES,
+      generatedAt: GENERATED_AT,
+    });
+    for (const slug of ['api', 'web']) {
+      expect(fs.existsSync(path.join(target, 'status', 'v1', 'entities', `${slug}.json`))).toBe(true);
+    }
+    const summary = parseSummary(
+      JSON.parse(fs.readFileSync(path.join(target, 'status', 'v1', 'summary.json'), 'utf8'))
+    );
+    expect(summary.entities.map(e => e.name)).toEqual(['api', 'web']);
+    expect(summary.entities[0].days.length).toBeGreaterThanOrEqual(90);
+  });
+});
+
+/** Read every legacy archive day back as readings (test-side golden source). */
+function readLegacyForGolden(dir: string): CompactReading[] {
+  const readings: CompactReading[] = [];
+  const walk = (p: string) => {
+    for (const entry of fs.readdirSync(p, {withFileTypes: true})) {
+      const full = path.join(p, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else {
+        const body = entry.name.endsWith('.gz')
+          ? zlib.gunzipSync(fs.readFileSync(full)).toString('utf8')
+          : fs.readFileSync(full, 'utf8');
+        for (const line of body.split('\n')) {
+          if (line.trim()) readings.push(JSON.parse(line));
+        }
+      }
+    }
+  };
+  walk(path.join(dir, 'archives'));
+  return readings;
+}
+
+describe('daily-summary-only days (archives pruned)', () => {
+  it('synthesizes days that reproduce uptimePct and avgLatencyMs exactly', () => {
+    // Only 7 days of archives, but daily-summary covers 30 — the 23
+    // older days exist ONLY as day rollups.
+    for (let d = 6; d >= 0; d--) {
+      const dayStart = NOW - d * DAY_MS - (NOW % DAY_MS);
+      writeLegacyArchiveDay(legacy, dayStart, makeReadings('api', dayStart, 24, 0));
+    }
+    const services: Record<string, unknown[]> = {api: []};
+    for (let d = 29; d >= 0; d--) {
+      const dayStart = NOW - d * DAY_MS - (NOW % DAY_MS);
+      services.api.push({
+        date: utcDate(dayStart),
+        uptimePct: d >= 7 ? (d % 3 === 0 ? 287 / 288 : 1) : 1,
+        avgLatencyMs: d >= 7 ? 40 + d : 40,
+        p95LatencyMs: 60,
+        checksTotal: 288,
+        checksPassed: d >= 7 && d % 3 === 0 ? 287 : 288,
+        incidentCount: 0,
+      });
+    }
+    fs.writeFileSync(
+      path.join(legacy, 'daily-summary.json'),
+      JSON.stringify({version: 1, lastUpdated: GENERATED_AT, windowDays: 90, services})
+    );
+
+    const report = migrateHistoricalData({
+      legacyDir: legacy,
+      targetDir: target,
+      entities: [{name: 'api', type: 'system'}],
+      generatedAt: GENERATED_AT,
+    });
+    expect(report.synthesizedDays).toBe(23);
+
+    const rollups = buildDailyRollups(readArchiveReadings(target, 90, NOW));
+    expect(rollups.api).toHaveLength(30);
+    for (const day of rollups.api) {
+      const src = (services.api as Array<{date: string; uptimePct: number; avgLatencyMs: number}>).find(
+        s => s.date === day.date
+      )!;
+      expect(day.uptime).toBeCloseTo(src.uptimePct * 100, 10);
+      if (day.date < utcDate(NOW - 6 * DAY_MS)) {
+        // synthesized day: avg latency must match the recorded rollup
+        expect(day.avgMs).toBe(src.avgLatencyMs);
+        expect(day.worst).toBe(src.uptimePct < 1 ? 'down' : 'up');
+      }
+    }
+  });
+});
+
+describe('pre-0.17 site (no daily-summary.json)', () => {
+  it('migrates from archives + current.json alone', () => {
+    for (let d = 13; d >= 0; d--) {
+      const dayStart = NOW - d * DAY_MS - (NOW % DAY_MS);
+      writeLegacyArchiveDay(legacy, dayStart, makeReadings('api', dayStart, 12, 0), d > 0);
+    }
+    const report = migrateHistoricalData({
+      legacyDir: legacy,
+      targetDir: target,
+      entities: [{name: 'api', type: 'system'}],
+      generatedAt: GENERATED_AT,
+    });
+    expect(report.synthesizedDays).toBe(0);
+    const rollups = buildDailyRollups(readArchiveReadings(target, 90, NOW));
+    expect(rollups.api).toHaveLength(14);
+  });
+});
+
+describe('pre-three-file site (systems/*.json only)', () => {
+  it('converts history entries to compact readings', () => {
+    const sysDir = path.join(legacy, 'systems');
+    fs.mkdirSync(sysDir, {recursive: true});
+    const history = [];
+    for (let i = 0; i < 48; i++) {
+      history.push({
+        timestamp: new Date(NOW - (48 - i) * 30 * 60_000).toISOString(),
+        status: i === 10 ? 'down' : 'up',
+        code: i === 10 ? 500 : 200,
+        responseTime: 55,
+      });
+    }
+    fs.writeFileSync(path.join(sysDir, 'api.json'), JSON.stringify({name: 'api', history}));
+
+    const report = migrateHistoricalData({
+      legacyDir: legacy,
+      targetDir: target,
+      entities: [{name: 'api', type: 'system'}],
+      generatedAt: GENERATED_AT,
+    });
+    expect(report.readingsMigrated).toBe(48);
+    const rollups = buildDailyRollups(readArchiveReadings(target, 90, NOW));
+    const total = rollups.api.reduce((n, d) => n + 1, 0);
+    expect(total).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('idempotency and resumability', () => {
+  it('re-running converges to identical output (no duplicated readings)', () => {
+    buildV021Fixture(legacy);
+    const opts = {legacyDir: legacy, targetDir: target, entities: ENTITIES, generatedAt: GENERATED_AT};
+    migrateHistoricalData(opts);
+    const first = buildDailyRollups(readArchiveReadings(target, 90, NOW));
+    migrateHistoricalData(opts);
+    const second = buildDailyRollups(readArchiveReadings(target, 90, NOW));
+    expect(second).toEqual(first);
+  });
+
+  it('completes cleanly after a simulated mid-migration crash', () => {
+    buildV021Fixture(legacy);
+    const opts = {legacyDir: legacy, targetDir: target, entities: ENTITIES, generatedAt: GENERATED_AT};
+    migrateHistoricalData(opts);
+    // Simulate a crash that lost half the outputs.
+    const archives = path.join(target, 'status', 'v1', 'archives');
+    const years = fs.readdirSync(archives);
+    fs.rmSync(path.join(archives, years[0]), {recursive: true});
+    fs.rmSync(path.join(target, 'status', 'v1', 'summary.json'));
+    migrateHistoricalData(opts);
+    const rollups = buildDailyRollups(readArchiveReadings(target, 90, NOW));
+    expect(rollups.api).toHaveLength(90);
+    expect(fs.existsSync(path.join(target, 'status', 'v1', 'summary.json'))).toBe(true);
+  });
+});
+
+describe('edge cases', () => {
+  it('skips corrupt JSONL lines and reports them without aborting', () => {
+    const dayStart = NOW - (NOW % DAY_MS);
+    writeLegacyArchiveDay(legacy, dayStart, makeReadings('api', dayStart, 5, 0));
+    const y = new Date(dayStart).toISOString().slice(0, 4);
+    const m = new Date(dayStart).toISOString().slice(5, 7);
+    const d = new Date(dayStart).toISOString().slice(8, 10);
+    const file = path.join(legacy, 'archives', y, m, `history-${y}-${m}-${d}.jsonl`);
+    fs.appendFileSync(file, 'NOT JSON AT ALL\n{"t":1,"svc":"api"}\n'); // corrupt + wrong shape
+
+    const report = migrateHistoricalData({
+      legacyDir: legacy,
+      targetDir: target,
+      entities: [{name: 'api', type: 'system'}],
+      generatedAt: GENERATED_AT,
+    });
+    expect(report.corruptLines).toBe(2);
+    expect(report.readingsMigrated).toBe(5);
+  });
+
+  it('reports ghost entities present in data but absent from config (#62)', () => {
+    const dayStart = NOW - (NOW % DAY_MS);
+    writeLegacyArchiveDay(legacy, dayStart, [
+      ...makeReadings('api', dayStart, 3, 0),
+      ...makeReadings('ghost', dayStart, 3, 0),
+    ]);
+    const report = migrateHistoricalData({
+      legacyDir: legacy,
+      targetDir: target,
+      entities: [{name: 'api', type: 'system'}],
+      generatedAt: GENERATED_AT,
+    });
+    expect(report.ghostEntities).toEqual(['ghost']);
+    // Ghost readings are preserved in archives (data is never dropped)…
+    const rollups = buildDailyRollups(readArchiveReadings(target, 90, NOW));
+    expect(rollups.ghost).toBeDefined();
+    // …but no entity detail file is written for them, and the summary
+    // only lists configured entities.
+    expect(fs.existsSync(path.join(target, 'status', 'v1', 'entities', 'ghost.json'))).toBe(false);
+    const summary = parseSummary(
+      JSON.parse(fs.readFileSync(path.join(target, 'status', 'v1', 'summary.json'), 'utf8'))
+    );
+    expect(summary.entities.map(e => e.name)).toEqual(['api']);
+  });
+
+  it('deduplicates readings that appear in both current.json and archives', () => {
+    const dayStart = NOW - (NOW % DAY_MS);
+    const readings = makeReadings('api', dayStart, 6, 0);
+    writeLegacyArchiveDay(legacy, dayStart, readings);
+    fs.writeFileSync(path.join(legacy, 'current.json'), JSON.stringify(readings));
+    const report = migrateHistoricalData({
+      legacyDir: legacy,
+      targetDir: target,
+      entities: [{name: 'api', type: 'system'}],
+      generatedAt: GENERATED_AT,
+    });
+    expect(report.readingsMigrated).toBe(6);
+  });
+});
+
+describe('planMigration (--dry-run)', () => {
+  it('reports the exact file plan without writing anything', () => {
+    buildV021Fixture(legacy);
+    const plan = planMigration({
+      legacyDir: legacy,
+      targetDir: target,
+      entities: ENTITIES,
+      generatedAt: GENERATED_AT,
+    });
+    expect(plan.archiveFiles.length).toBe(90);
+    expect(plan.entityFiles).toEqual([
+      path.join('status', 'v1', 'entities', 'api.json'),
+      path.join('status', 'v1', 'entities', 'web.json'),
+    ]);
+    expect(plan.report.readingsMigrated).toBeGreaterThan(0);
+    // Nothing written:
+    expect(fs.existsSync(path.join(target, 'status'))).toBe(false);
+  });
+});
+
+describe('stentorosaur migrate (CLI)', () => {
+  it('--dry-run prints the plan and writes nothing', async () => {
+    const {main} = await import('../src/cli');
+    buildV021Fixture(legacy);
+    fs.writeFileSync(
+      path.join(target, 'stentorosaur.config.js'),
+      `module.exports = {owner: 'o', repo: 'r', entities: [
+        {name: 'api', type: 'system'},
+        {name: 'web', type: 'system'},
+      ]};`
+    );
+    const code = await main([
+      'migrate', '--config', target, '--workdir', target, '--from', legacy, '--dry-run',
+    ]);
+    expect(code).toBe(0);
+    expect(fs.existsSync(path.join(target, 'status'))).toBe(false);
+  });
+
+  it('runs the full local migration with --no-push', async () => {
+    const {main} = await import('../src/cli');
+    buildV021Fixture(legacy);
+    fs.writeFileSync(
+      path.join(target, 'stentorosaur.config.js'),
+      `module.exports = {owner: 'o', repo: 'r', entities: [
+        {name: 'api', type: 'system'},
+        {name: 'web', type: 'system'},
+      ]};`
+    );
+    const code = await main([
+      'migrate', '--config', target, '--workdir', target, '--from', legacy, '--no-push',
+    ]);
+    expect(code).toBe(0);
+    const summary = parseSummary(
+      JSON.parse(fs.readFileSync(path.join(target, 'status', 'v1', 'summary.json'), 'utf8'))
+    );
+    expect(summary.entities.map(e => e.name)).toEqual(['api', 'web']);
+    expect(summary.entities[0].uptime.d90).toBeGreaterThan(0);
+  });
+
+  it('converts .monitorrc.json to a config scaffold when no config exists', async () => {
+    const {main} = await import('../src/cli');
+    const {loadConfig} = await import('../src/config-loader');
+    fs.writeFileSync(
+      path.join(target, '.monitorrc.json'),
+      JSON.stringify({
+        systems: [
+          {system: 'api', url: 'https://api.example.com/health', expectedCodes: [200, 302], timeout: 5000},
+          {system: 'web', url: 'https://example.com'},
+        ],
+      })
+    );
+    const code = await main(['migrate', '--config', target, '--workdir', target, '--from', legacy]);
+    expect(code).toBe(1); // stops for owner/repo fill-in
+    const configFile = path.join(target, 'stentorosaur.config.js');
+    expect(fs.existsSync(configFile)).toBe(true);
+    const config = await loadConfig(target); // placeholder owner/repo still parse
+    expect(config.entities.map(e => e.name)).toEqual(['api', 'web']);
+    expect(config.entities[0].probe?.expectedCodes).toEqual([200, 302]);
+  });
+});
+
+describe('collectLegacyData sources', () => {
+  it('reads gzipped archives, current.json, and systems/*.json together', () => {
+    const dayStart = NOW - (NOW % DAY_MS);
+    writeLegacyArchiveDay(legacy, dayStart - DAY_MS, makeReadings('api', dayStart - DAY_MS, 4, 0), true);
+    fs.writeFileSync(path.join(legacy, 'current.json'), JSON.stringify(makeReadings('api', dayStart, 4, 0)));
+    const sysDir = path.join(legacy, 'systems');
+    fs.mkdirSync(sysDir);
+    fs.writeFileSync(
+      path.join(sysDir, 'web.json'),
+      JSON.stringify({
+        name: 'web',
+        history: [{timestamp: new Date(dayStart).toISOString(), status: 'up', code: 200, responseTime: 20}],
+      })
+    );
+    const collected = collectLegacyData(legacy);
+    expect(collected.readings).toHaveLength(9);
+    expect(collected.sources.sort()).toEqual(['archives', 'current.json', 'systems/web.json'].sort());
+  });
+});

--- a/packages/probe/__tests__/migrate.test.ts
+++ b/packages/probe/__tests__/migrate.test.ts
@@ -326,6 +326,28 @@ describe('edge cases', () => {
     expect(summary.entities.map(e => e.name)).toEqual(['api']);
   });
 
+  it('continues reading remaining files after one unreadable archive in the same directory', () => {
+    // Two good days in the same month directory, with a corrupt .gz sandwiched between them.
+    const dayStart0 = NOW - 2 * DAY_MS - (NOW % DAY_MS);
+    const dayStart1 = NOW - 1 * DAY_MS - (NOW % DAY_MS);
+    const dayStart2 = NOW - (NOW % DAY_MS);
+    writeLegacyArchiveDay(legacy, dayStart0, makeReadings('api', dayStart0, 3, 0));
+    writeLegacyArchiveDay(legacy, dayStart2, makeReadings('api', dayStart2, 3, 0));
+    // Corrupt gzip between the two good days (same directory).
+    const y = new Date(dayStart1).toISOString().slice(0, 4);
+    const m = new Date(dayStart1).toISOString().slice(5, 7);
+    const d = new Date(dayStart1).toISOString().slice(8, 10);
+    const corruptFile = path.join(legacy, 'archives', y, m, `history-${y}-${m}-${d}.jsonl.gz`);
+    fs.mkdirSync(path.dirname(corruptFile), {recursive: true});
+    fs.writeFileSync(corruptFile, Buffer.from('this is not a valid gzip'));
+
+    const warnings: string[] = [];
+    const collected = collectLegacyData(legacy, msg => warnings.push(msg));
+    expect(warnings).toHaveLength(1);
+    // Both good days must be collected — the corrupt file must not stop the walk.
+    expect(collected.readings).toHaveLength(6);
+  });
+
   it('deduplicates readings that appear in both current.json and archives', () => {
     const dayStart = NOW - (NOW % DAY_MS);
     const readings = makeReadings('api', dayStart, 6, 0);

--- a/packages/probe/src/cli.ts
+++ b/packages/probe/src/cli.ts
@@ -7,6 +7,7 @@
  *   stentorosaur probe              run checks, write + push (§5 retry)
  *   stentorosaur update-incidents   sync issues, write + push (§5 retry)
  *   stentorosaur regenerate         §7 re-render from raw/ + rebuild
+ *   stentorosaur migrate            one-time legacy → status/v1 (#75)
  *
  * probe/update-incidents/regenerate operate on a git worktree of the
  * data branch (the workflow templates check it out first) or any dir
@@ -23,6 +24,8 @@ import {pushWithRegenerateRetry} from './git-writer';
 import {regenerateDerived} from './regenerate';
 import {reRenderFromRaw} from './regenerate-from-raw';
 import {fetchStatusIssues, writeIssueInputs} from './update-incidents';
+import {migrateHistoricalData, planMigration} from './migrate';
+import type {MigrationReport} from './migrate';
 import {parseSummary} from '@stentorosaur/core';
 import type {StentorosaurConfig} from '@stentorosaur/core';
 
@@ -31,11 +34,21 @@ interface CliOptions {
   workdir: string;
   branch?: string;
   push: boolean;
+  /** migrate: legacy status-data directory */
+  from: string;
+  /** migrate: plan only, write nothing */
+  dryRun: boolean;
 }
 
 function parseArgs(argv: string[]): {command: string; options: CliOptions} {
   const [command = 'help', ...rest] = argv;
-  const options: CliOptions = {config: process.cwd(), workdir: process.cwd(), push: true};
+  const options: CliOptions = {
+    config: process.cwd(),
+    workdir: process.cwd(),
+    push: true,
+    from: 'status-data',
+    dryRun: false,
+  };
   const takeValue = (flag: string, i: number): string => {
     const value = rest[i];
     if (value === undefined || value.startsWith('--')) {
@@ -56,6 +69,12 @@ function parseArgs(argv: string[]): {command: string; options: CliOptions} {
         break;
       case '--no-push':
         options.push = false;
+        break;
+      case '--from':
+        options.from = takeValue('--from', ++i);
+        break;
+      case '--dry-run':
+        options.dryRun = true;
         break;
       default:
         throw new Error(`unknown flag: ${rest[i]}`);
@@ -268,6 +287,121 @@ async function cmdRegenerate(options: CliOptions): Promise<number> {
   return 0;
 }
 
+/**
+ * .monitorrc.json systems → stentorosaur.config.js scaffold (ADR-005
+ * Migration Phase 1: config conversion half of `stentorosaur migrate`).
+ * Owner/repo aren't recorded in .monitorrc.json, so they land as
+ * placeholders the user must fill in before the data migration runs.
+ */
+function monitorrcToConfigSource(monitorrcPath: string): string {
+  const rc = JSON.parse(fs.readFileSync(monitorrcPath, 'utf8')) as {
+    systems?: Array<{
+      system?: string;
+      url?: string;
+      method?: string;
+      timeout?: number;
+      expectedCodes?: number[];
+      maxResponseTime?: number;
+    }>;
+  };
+  const entities = (rc.systems ?? [])
+    .filter(s => s.system)
+    .map(s => ({
+      name: s.system!,
+      type: 'system' as const,
+      ...(s.url
+        ? {
+            probe: {
+              url: s.url,
+              ...(s.method && s.method !== 'GET' ? {method: s.method} : {}),
+              ...(s.timeout ? {timeout: s.timeout} : {}),
+              ...(s.expectedCodes ? {expectedCodes: s.expectedCodes} : {}),
+              ...(s.maxResponseTime ? {maxResponseTime: s.maxResponseTime} : {}),
+            },
+          }
+        : {}),
+    }));
+  const config = {
+    owner: 'OWNER',
+    repo: 'REPO',
+    dataBranch: 'status-data',
+    entities,
+    site: {title: 'System Status'},
+  };
+  return (
+    '// Migrated from .monitorrc.json by `stentorosaur migrate`.\n' +
+    '// FILL IN owner/repo before running the data migration.\n\n' +
+    `/** @type {import('@stentorosaur/core').StentorosaurConfigInput} */\n` +
+    `module.exports = ${JSON.stringify(config, null, 2)};\n`
+  );
+}
+
+async function cmdMigrate(options: CliOptions): Promise<number> {
+  const legacyDir = path.resolve(options.from);
+
+  // Config half first: no stentorosaur config yet + a .monitorrc.json
+  // present → convert it, then stop so the user fills in owner/repo.
+  if (!findConfigFile(options.workdir)) {
+    const monitorrc = path.join(path.dirname(legacyDir), '.monitorrc.json');
+    const fallback = path.join(options.workdir, '.monitorrc.json');
+    const rcPath = fs.existsSync(monitorrc) ? monitorrc : fs.existsSync(fallback) ? fallback : null;
+    if (rcPath) {
+      const target = path.join(options.workdir, 'stentorosaur.config.js');
+      fs.writeFileSync(target, monitorrcToConfigSource(rcPath));
+      console.log(`converted ${rcPath} → ${target}`);
+      console.log('Fill in owner/repo, then re-run `stentorosaur migrate` for the data migration.');
+      return 1;
+    }
+    console.error("no stentorosaur config and no .monitorrc.json found — run 'stentorosaur init' first");
+    return 1;
+  }
+
+  const config = await loadConfig(options.config);
+  if (!fs.existsSync(legacyDir)) {
+    console.error(`legacy status-data directory not found: ${legacyDir} (use --from <dir>)`);
+    return 1;
+  }
+
+  const migrateOpts = {
+    legacyDir,
+    entities: config.entities.map(({name, type, displayName}) => ({
+      name,
+      type,
+      ...(displayName ? {displayName} : {}),
+    })),
+    siteTitle: config.site.title,
+    siteUrl: config.site.url ?? `https://github.com/${config.owner}/${config.repo}`,
+    onWarn: (message: string) => console.warn(`  ⚠ ${message}`),
+  };
+
+  if (options.dryRun) {
+    const plan = planMigration({...migrateOpts, targetDir: options.workdir, generatedAt: new Date().toISOString()});
+    const r = plan.report;
+    console.log(`dry run — nothing written. Plan from ${legacyDir}:`);
+    console.log(`  sources: ${r.sources.join(', ') || '(none found)'}`);
+    console.log(`  ${r.readingsMigrated} readings across ${plan.days.size} days (${r.synthesizedDays} days synthesized from daily-summary.json)`);
+    if (r.corruptLines > 0) console.log(`  ${r.corruptLines} corrupt lines will be skipped`);
+    if (r.ghostEntities.length > 0)
+      console.log(`  ghost entities in data but not config (archived, not summarized): ${r.ghostEntities.join(', ')}`);
+    console.log(`  would write ${plan.archiveFiles.length} archive files + ${plan.entityFiles.length} entity details + summary.json:`);
+    for (const f of [...plan.archiveFiles, ...plan.entityFiles]) console.log(`    ${f}`);
+    return 0;
+  }
+
+  let report: MigrationReport | null = null;
+  await withDataBranch(options, config, 'migrate: legacy status-data → status/v1', async (dir, generatedAt) => {
+    report = migrateHistoricalData({...migrateOpts, targetDir: dir, generatedAt});
+  });
+  if (report) {
+    const r: MigrationReport = report;
+    console.log(`migrated ${r.readingsMigrated} readings (${r.synthesizedDays} days synthesized, ${r.corruptLines} corrupt lines skipped)`);
+    if (r.ghostEntities.length > 0)
+      console.log(`ghost entities preserved in archives only: ${r.ghostEntities.join(', ')}`);
+  }
+  console.log('legacy files were not modified — remove status-data/ after verifying the site renders.');
+  return 0;
+}
+
 export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
   try {
     const {command, options} = parseArgs(argv);
@@ -282,8 +416,10 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
         return await cmdUpdateIncidents(options);
       case 'regenerate':
         return await cmdRegenerate(options);
+      case 'migrate':
+        return await cmdMigrate(options);
       default:
-        console.log('usage: stentorosaur <init|doctor|probe|update-incidents|regenerate> [--config <file-or-dir>] [--workdir <dir>] [--branch <name>] [--no-push]');
+        console.log('usage: stentorosaur <init|doctor|probe|update-incidents|regenerate|migrate> [--config <file-or-dir>] [--workdir <dir>] [--branch <name>] [--no-push] [--from <legacy-dir>] [--dry-run]');
         return command === 'help' ? 0 : 1;
     }
   } catch (error) {

--- a/packages/probe/src/index.ts
+++ b/packages/probe/src/index.ts
@@ -14,4 +14,5 @@ export * from './update-incidents';
 export * from './compact';
 export * from './config-loader';
 export * from './regenerate-from-raw';
+export * from './migrate';
 export * from './cli';

--- a/packages/probe/src/migrate.ts
+++ b/packages/probe/src/migrate.ts
@@ -1,0 +1,355 @@
+/**
+ * One-time historical data migration (ADR-005 Migration Phase 1, council
+ * condition 6; epic #63 ticket #75): legacy `status-data/` files
+ * (current.json, daily-summary.json, systems/*.json, archives/**) →
+ * `status/v1/` on the data branch, so the 90-day view is intact on the
+ * first render after upgrade.
+ *
+ * Design constraints:
+ * - The v1 pipeline rebuilds day rollups from status/v1/archives on
+ *   EVERY regenerate, so history must land as archive readings — real
+ *   ones where the legacy site has them, and synthesized ones that
+ *   reproduce the recorded rollup exactly for days covered only by
+ *   daily-summary.json (pruned/pre-archive sites).
+ * - Idempotent and resumable: day files are written whole (merge with
+ *   any existing target file, dedupe by svc+timestamp, sort) so a
+ *   re-run after a partial failure converges. Legacy files are never
+ *   modified or deleted.
+ * - Corrupt JSONL lines are skipped and counted, never fatal.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import {compactReadingSchema} from '@stentorosaur/core';
+import type {CompactReading, EntityRef} from '@stentorosaur/core';
+import {entitySlug, writeEntityDetail} from './files';
+import {regenerateDerived} from './regenerate';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CURRENT_WINDOW_DAYS = 14;
+
+export interface LegacyCollection {
+  /** Deduplicated by (svc, t); order unspecified */
+  readings: CompactReading[];
+  corruptLines: number;
+  /** Which legacy sources contributed (for the plan report) */
+  sources: string[];
+}
+
+interface LegacyDayEntry {
+  date: string;
+  uptimePct: number;
+  avgLatencyMs: number | null;
+  checksTotal?: number;
+  checksPassed?: number;
+}
+
+export interface MigrateOptions {
+  legacyDir: string;
+  targetDir: string;
+  entities: EntityRef[];
+  /** Injected — one clock read at the CLI boundary */
+  generatedAt: string;
+  siteTitle?: string;
+  siteUrl?: string;
+  onWarn?: (message: string) => void;
+}
+
+export interface MigrationReport {
+  readingsMigrated: number;
+  synthesizedDays: number;
+  corruptLines: number;
+  ghostEntities: string[];
+  sources: string[];
+}
+
+export interface MigrationPlan {
+  /** Target-relative archive file paths, one per day, oldest first */
+  archiveFiles: string[];
+  /** Target-relative entity detail paths for configured entities */
+  entityFiles: string[];
+  /** date → merged readings for that UTC day (real + synthesized) */
+  days: Map<string, CompactReading[]>;
+  report: MigrationReport;
+}
+
+function utcDate(ms: number): string {
+  return new Date(ms).toISOString().split('T')[0];
+}
+
+function readingKey(r: CompactReading): string {
+  return `${r.svc}|${r.t}`;
+}
+
+/** Gather every reading the legacy site has, across all generations. */
+export function collectLegacyData(
+  legacyDir: string,
+  onWarn: (message: string) => void = () => {}
+): LegacyCollection {
+  const byKey = new Map<string, CompactReading>();
+  let corruptLines = 0;
+  const sources: string[] = [];
+
+  const addReading = (raw: unknown): boolean => {
+    const parsed = compactReadingSchema.safeParse(raw);
+    if (!parsed.success) return false;
+    const key = readingKey(parsed.data);
+    if (!byKey.has(key)) byKey.set(key, parsed.data);
+    return true;
+  };
+
+  // 1. archives/**/history-*.jsonl(.gz) — the richest source.
+  const archivesDir = path.join(legacyDir, 'archives');
+  if (fs.existsSync(archivesDir)) {
+    let contributed = false;
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (/^history-.*\.jsonl(\.gz)?$/.test(entry.name)) {
+          let body: string;
+          try {
+            body = entry.name.endsWith('.gz')
+              ? zlib.gunzipSync(fs.readFileSync(full)).toString('utf8')
+              : fs.readFileSync(full, 'utf8');
+          } catch (error) {
+            onWarn(`unreadable archive ${full}: ${String(error)}`);
+            return;
+          }
+          for (const line of body.split('\n')) {
+            if (!line.trim()) continue;
+            try {
+              if (addReading(JSON.parse(line))) contributed = true;
+              else corruptLines++;
+            } catch {
+              corruptLines++;
+            }
+          }
+        }
+      }
+    };
+    walk(archivesDir);
+    if (contributed) sources.push('archives');
+  }
+
+  // 2. current.json — overlaps archives by design; dedupe handles it.
+  const currentFile = path.join(legacyDir, 'current.json');
+  if (fs.existsSync(currentFile)) {
+    try {
+      const arr = JSON.parse(fs.readFileSync(currentFile, 'utf8'));
+      if (Array.isArray(arr)) {
+        let contributed = false;
+        for (const raw of arr) {
+          if (addReading(raw)) contributed = true;
+          else corruptLines++;
+        }
+        if (contributed) sources.push('current.json');
+      }
+    } catch (error) {
+      onWarn(`unreadable current.json: ${String(error)}`);
+    }
+  }
+
+  // 3. systems/*.json — the pre-three-file generation.
+  const systemsDir = path.join(legacyDir, 'systems');
+  if (fs.existsSync(systemsDir)) {
+    for (const f of fs.readdirSync(systemsDir).filter(f => f.endsWith('.json'))) {
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(systemsDir, f), 'utf8')) as {
+          name?: string;
+          history?: Array<{timestamp?: string; status?: string; code?: number; responseTime?: number}>;
+        };
+        const svc = data.name ?? path.basename(f, '.json');
+        let contributed = false;
+        for (const h of data.history ?? []) {
+          const t = h.timestamp ? Date.parse(h.timestamp) : NaN;
+          if (
+            !Number.isNaN(t) &&
+            addReading({t, svc, state: h.status, code: h.code ?? 0, lat: h.responseTime ?? 0})
+          ) {
+            contributed = true;
+          } else {
+            corruptLines++;
+          }
+        }
+        if (contributed) sources.push(`systems/${f}`);
+      } catch (error) {
+        onWarn(`unreadable systems/${f}: ${String(error)}`);
+      }
+    }
+  }
+
+  return {readings: [...byKey.values()], corruptLines, sources};
+}
+
+function readDailySummary(
+  legacyDir: string,
+  onWarn: (message: string) => void
+): Map<string, LegacyDayEntry[]> {
+  const map = new Map<string, LegacyDayEntry[]>();
+  const file = path.join(legacyDir, 'daily-summary.json');
+  if (!fs.existsSync(file)) return map;
+  try {
+    const data = JSON.parse(fs.readFileSync(file, 'utf8')) as {
+      services?: Record<string, LegacyDayEntry[]>;
+    };
+    for (const [svc, entries] of Object.entries(data.services ?? {})) {
+      if (Array.isArray(entries)) map.set(svc, entries);
+    }
+  } catch (error) {
+    onWarn(`unreadable daily-summary.json: ${String(error)}`);
+  }
+  return map;
+}
+
+/**
+ * Synthesize a day of readings that reproduces the recorded rollup
+ * EXACTLY under core aggregation: `checksPassed` up readings at
+ * lat=avgLatencyMs (avg over up readings == avgLatencyMs), the rest
+ * down. When the rollup says checks passed but records no latency
+ * (an all-maintenance day), 'maintenance' readings preserve the pass
+ * count without polluting the latency average.
+ */
+function synthesizeDayReadings(svc: string, entry: LegacyDayEntry): CompactReading[] {
+  // uptimePct is a fraction in every known generation; tolerate percent.
+  const fraction = entry.uptimePct > 1 ? entry.uptimePct / 100 : entry.uptimePct;
+  const total =
+    entry.checksTotal && entry.checksTotal > 0 ? entry.checksTotal : 288;
+  const passed =
+    entry.checksPassed !== undefined
+      ? entry.checksPassed
+      : Math.round(fraction * total);
+
+  const dayStart = Date.parse(`${entry.date}T00:00:00.000Z`);
+  const step = Math.max(1, Math.floor(DAY_MS / Math.max(total, 1)));
+  const readings: CompactReading[] = [];
+  for (let i = 0; i < total; i++) {
+    const up = i < passed;
+    readings.push({
+      t: dayStart + i * step,
+      svc,
+      state: up ? (entry.avgLatencyMs === null ? 'maintenance' : 'up') : 'down',
+      code: up ? 200 : 0,
+      lat: up ? entry.avgLatencyMs ?? 0 : 0,
+    });
+  }
+  return readings;
+}
+
+function archiveRelPath(date: string): string {
+  const [y, m] = date.split('-');
+  return path.join('status', 'v1', 'archives', y, m, `history-${date}.jsonl`);
+}
+
+export function planMigration(options: MigrateOptions): MigrationPlan {
+  const warn = options.onWarn ?? (() => {});
+  const collected = collectLegacyData(options.legacyDir, warn);
+  const dailySummary = readDailySummary(options.legacyDir, warn);
+
+  // Group real readings by UTC day, tracking which (svc, day) pairs
+  // have real coverage so we only synthesize the genuinely missing ones.
+  const days = new Map<string, CompactReading[]>();
+  const coveredSvcDays = new Set<string>();
+  for (const reading of collected.readings) {
+    const date = utcDate(reading.t);
+    days.set(date, [...(days.get(date) ?? []), reading]);
+    coveredSvcDays.add(`${reading.svc}|${date}`);
+  }
+
+  let synthesizedDays = 0;
+  for (const [svc, entries] of dailySummary) {
+    for (const entry of entries) {
+      if (!entry?.date || coveredSvcDays.has(`${svc}|${entry.date}`)) continue;
+      const synthesized = synthesizeDayReadings(svc, entry);
+      days.set(entry.date, [...(days.get(entry.date) ?? []), ...synthesized]);
+      synthesizedDays++;
+    }
+  }
+
+  for (const readings of days.values()) {
+    readings.sort((a, b) => a.t - b.t || a.svc.localeCompare(b.svc));
+  }
+
+  const configuredNames = new Set(options.entities.map(e => e.name));
+  const dataSvcs = new Set<string>();
+  for (const readings of days.values()) {
+    for (const r of readings) dataSvcs.add(r.svc);
+  }
+  const ghostEntities = [...dataSvcs].filter(svc => !configuredNames.has(svc)).sort();
+
+  const sortedDates = [...days.keys()].sort();
+  return {
+    archiveFiles: sortedDates.map(archiveRelPath),
+    entityFiles: options.entities.map(e =>
+      path.join('status', 'v1', 'entities', `${entitySlug(e.name)}.json`)
+    ),
+    days,
+    report: {
+      readingsMigrated: collected.readings.length,
+      synthesizedDays,
+      corruptLines: collected.corruptLines,
+      ghostEntities,
+      sources: collected.sources,
+    },
+  };
+}
+
+export function migrateHistoricalData(options: MigrateOptions): MigrationReport {
+  const plan = planMigration(options);
+  const {targetDir, entities, generatedAt} = options;
+
+  // Whole-file day writes: merge with anything already at the target
+  // (a prior partial run, or probe readings that landed post-cutover),
+  // dedupe by (svc, t), sort. Deterministic → idempotent.
+  for (const [date, readings] of plan.days) {
+    const rel = archiveRelPath(date);
+    const file = path.join(targetDir, rel);
+    const byKey = new Map<string, CompactReading>();
+    if (fs.existsSync(file)) {
+      for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const parsed = compactReadingSchema.safeParse(JSON.parse(line));
+          if (parsed.success) byKey.set(readingKey(parsed.data), parsed.data);
+        } catch {
+          // A corrupt pre-existing target line is dropped by the rewrite.
+        }
+      }
+    }
+    for (const reading of readings) {
+      if (!byKey.has(readingKey(reading))) byKey.set(readingKey(reading), reading);
+    }
+    const merged = [...byKey.values()].sort((a, b) => a.t - b.t || a.svc.localeCompare(b.svc));
+    fs.mkdirSync(path.dirname(file), {recursive: true});
+    fs.writeFileSync(file, merged.map(r => JSON.stringify(r)).join('\n') + '\n');
+  }
+
+  // Entity details for configured entities: the recent window, matching
+  // what a probe run would leave behind.
+  const generatedAtMs = Date.parse(generatedAt);
+  const windowStart = generatedAtMs - CURRENT_WINDOW_DAYS * DAY_MS;
+  const recentBySvc = new Map<string, CompactReading[]>();
+  for (const readings of plan.days.values()) {
+    for (const r of readings) {
+      if (r.t >= windowStart) {
+        recentBySvc.set(r.svc, [...(recentBySvc.get(r.svc) ?? []), r]);
+      }
+    }
+  }
+  for (const entity of entities) {
+    const readings = (recentBySvc.get(entity.name) ?? []).sort((a, b) => a.t - b.t);
+    writeEntityDetail(targetDir, entity.name, readings, generatedAt);
+  }
+
+  regenerateDerived(targetDir, {
+    generatedAt,
+    generatedBy: 'stentorosaur-migrate',
+    entities,
+    siteTitle: options.siteTitle ?? 'System Status',
+    siteUrl: options.siteUrl ?? 'https://example.com',
+  });
+
+  return plan.report;
+}

--- a/packages/probe/src/migrate.ts
+++ b/packages/probe/src/migrate.ts
@@ -116,7 +116,7 @@ export function collectLegacyData(
               : fs.readFileSync(full, 'utf8');
           } catch (error) {
             onWarn(`unreadable archive ${full}: ${String(error)}`);
-            return;
+            continue;
           }
           for (const line of body.split('\n')) {
             if (!line.trim()) continue;


### PR DESCRIPTION
Closes #75

## What

`stentorosaur migrate` — the one-time conversion of legacy `status-data/` into `status/v1/` on the data branch (ADR-005 Migration Phase 1, council condition 6: **no history reset at cutover**).

## How history survives

The v1 pipeline rebuilds day rollups from `status/v1/archives/**` on every regenerate, so migration materializes legacy history as archive readings:

- **Real readings** from all legacy generations — `archives/**` (JSONL + gzip), `current.json`, pre-three-file `systems/*.json` — deduped by `(svc, t)`
- **Synthesized readings** for days covered only by `daily-summary.json`: `checksPassed` up-readings at `lat = avgLatencyMs` + the remainder down, which reproduces the recorded `uptimePct`/`avgLatencyMs` **exactly** under core aggregation (golden test proves 90-day pre/post identity)

## Safety properties

- Idempotent + resumable: whole-file day writes merged with any existing target archive; re-run after a mid-migration crash converges (tested)
- Corrupt JSONL lines skipped + counted, never fatal
- Ghost entities (#62 shape) preserved in archives, excluded from entity details/summary, reported
- Legacy files never modified or deleted
- `--dry-run` prints the exact file plan, writes nothing
- No stentorosaur config + `.monitorrc.json` present → converts it to a `stentorosaur.config.js` scaffold and stops for owner/repo fill-in

## Tests

15 new tests: golden zero-loss (90 days, 2 entities), daily-summary-only synthesis exactness, pre-0.17 (no daily-summary), systems/*.json generation, idempotency, crash-resume, corrupt lines, ghosts, dedupe, dry-run, CLI e2e (--no-push), monitorrc conversion. Probe suite 72 green; core 63 green; build + typecheck green.