### PR TITLE
feat: dataPlane config block — git|r2 profile selection (#98)

### DIFF
--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -62,6 +62,29 @@ module.exports = {
 };
 ```
 
+### `dataPlane` (optional — ADR-006 Profile C)
+
+Absent means the git data branch (Profiles A/B) exactly as documented
+above. Opting into the R2 object-storage profile:
+
+```js
+dataPlane: {
+  kind: 'r2',                 // default: 'git'
+  bucket: 'status',
+  endpoint: 'https://<account>.r2.cloudflarestorage.com', // S3 API (CLI writes)
+  publicBaseUrl: 'https://status.example.com',            // what dataUrl points at (https only)
+},
+```
+
+All three r2 fields are required together; extra fields on the git
+profile are rejected (typos fail loudly instead of silently keeping
+git). **Budget** (ADR-006 §1): class-A writes/month ≈
+`runs_per_day × (N_entities + 3) × 30` — at 5-min cadence with 10
+entities ≈ 112k (11% of R2's 1M free tier); 1-min cadence with 25
+entities breaches it, which is why unchanged entity details are
+skipped by content hash. Serve `publicBaseUrl` behind a Cloudflare
+custom domain, never bare workers.dev (ADR-006 §2).
+
 Validate any time with `npx stentorosaur doctor`.
 
 ## Plugin options (`docusaurus.config.js`)

--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -68,8 +68,9 @@ Absent means the git data branch (Profiles A/B) exactly as documented
 above. Opting into the R2 object-storage profile:
 
 ```js
+// absent → the whole block defaults to {kind: 'git'}
 dataPlane: {
-  kind: 'r2',                 // default: 'git'
+  kind: 'r2',
   bucket: 'status',
   endpoint: 'https://<account>.r2.cloudflarestorage.com', // S3 API (CLI writes)
   publicBaseUrl: 'https://status.example.com',            // what dataUrl points at (https only)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24516,7 +24516,7 @@
     },
     "packages/docusaurus-plugin-stentorosaur": {
       "name": "@amiable-dev/docusaurus-plugin-stentorosaur",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/packages/core/__tests__/dataplane-config.test.ts
+++ b/packages/core/__tests__/dataplane-config.test.ts
@@ -1,0 +1,74 @@
+/**
+ * dataPlane config block tests (ADR-006 §6; epic #97 ticket #98).
+ *
+ * Profile selection is ONE optional block; absence must mean Profile
+ * A/B exactly as today — every existing config keeps parsing with
+ * `dataPlane.kind === 'git'`.
+ */
+
+import {parseConfig} from '../src/config';
+
+const BASE = {
+  owner: 'o',
+  repo: 'r',
+  entities: [{name: 'api', type: 'system' as const}],
+};
+
+describe('dataPlane config block (ADR-006 §6)', () => {
+  it('defaults to the git profile when absent (existing configs unaffected)', () => {
+    const config = parseConfig(BASE);
+    expect(config.dataPlane.kind).toBe('git');
+  });
+
+  it('accepts an explicit git profile with no further fields', () => {
+    const config = parseConfig({...BASE, dataPlane: {kind: 'git'}});
+    expect(config.dataPlane.kind).toBe('git');
+  });
+
+  it('accepts a complete r2 profile', () => {
+    const config = parseConfig({
+      ...BASE,
+      dataPlane: {
+        kind: 'r2',
+        bucket: 'status',
+        endpoint: 'https://abc123.r2.cloudflarestorage.com',
+        publicBaseUrl: 'https://status.example.com',
+      },
+    });
+    expect(config.dataPlane).toMatchObject({kind: 'r2', bucket: 'status'});
+  });
+
+  it.each([
+    ['bucket', {endpoint: 'https://a.r2.cloudflarestorage.com', publicBaseUrl: 'https://s.example.com'}],
+    ['endpoint', {bucket: 'status', publicBaseUrl: 'https://s.example.com'}],
+    ['publicBaseUrl', {bucket: 'status', endpoint: 'https://a.r2.cloudflarestorage.com'}],
+  ])('rejects an r2 profile missing %s with a field-path error', (missing, partial) => {
+    expect(() => parseConfig({...BASE, dataPlane: {kind: 'r2', ...partial}})).toThrow(
+      new RegExp(`dataPlane.*${missing}|${missing}.*dataPlane|${missing}`)
+    );
+  });
+
+  it('rejects a non-https publicBaseUrl (the client polls it)', () => {
+    expect(() =>
+      parseConfig({
+        ...BASE,
+        dataPlane: {
+          kind: 'r2',
+          bucket: 'status',
+          endpoint: 'https://a.r2.cloudflarestorage.com',
+          publicBaseUrl: 'http://insecure.example.com',
+        },
+      })
+    ).toThrow(/https/);
+  });
+
+  it('rejects an unknown kind', () => {
+    expect(() => parseConfig({...BASE, dataPlane: {kind: 's3'}})).toThrow();
+  });
+
+  it('rejects r2 fields on the git profile (catches option typos loudly)', () => {
+    expect(() =>
+      parseConfig({...BASE, dataPlane: {kind: 'git', bucket: 'status'}})
+    ).toThrow(/bucket/);
+  });
+});

--- a/packages/core/__tests__/dataplane-config.test.ts
+++ b/packages/core/__tests__/dataplane-config.test.ts
@@ -62,6 +62,20 @@ describe('dataPlane config block (ADR-006 §6)', () => {
     ).toThrow(/https/);
   });
 
+  it('rejects a non-https endpoint (credentials travel over it)', () => {
+    expect(() =>
+      parseConfig({
+        ...BASE,
+        dataPlane: {
+          kind: 'r2',
+          bucket: 'status',
+          endpoint: 'http://a.r2.cloudflarestorage.com',
+          publicBaseUrl: 'https://s.example.com',
+        },
+      })
+    ).toThrow(/https/);
+  });
+
   it('rejects an unknown kind', () => {
     expect(() => parseConfig({...BASE, dataPlane: {kind: 's3'}})).toThrow();
   });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -41,8 +41,14 @@ export const dataPlaneSchema = z
         kind: z.literal('r2'),
         /** R2 bucket name */
         bucket: z.string().min(1),
-        /** S3-compatible API endpoint (CLI writes) */
-        endpoint: z.string().url(),
+        /** S3-compatible API endpoint (CLI writes) — https only:
+         * R2 credentials travel over it (Copilot PR #105 r=1) */
+        endpoint: z
+          .string()
+          .url()
+          .refine(u => u.startsWith('https://'), {
+            message: 'endpoint must be https (credentials travel over it)',
+          }),
         /** Public base the plugin's dataUrl points at — the client
          * polls it, so https only (ADR-006 §2) */
         publicBaseUrl: z
@@ -86,6 +92,7 @@ export const stentorosaurConfigSchema = z.object({
     .optional(),
 });
 
+export type DataPlane = z.infer<typeof dataPlaneSchema>;
 export type StentorosaurConfig = z.infer<typeof stentorosaurConfigSchema>;
 export type StentorosaurConfigInput = z.input<typeof stentorosaurConfigSchema>;
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -26,11 +26,43 @@ export const configEntitySchema = z.object({
   probe: probeTargetSchema.optional(),
 });
 
+/**
+ * Data-plane profile selection (ADR-006 §6). Absent → Profile A/B (git
+ * data branch) exactly as before. A discriminated union so the r2
+ * fields are REQUIRED when selected and REJECTED on the git profile —
+ * a typo'd or half-configured profile must fail loudly, never fall
+ * back silently.
+ */
+export const dataPlaneSchema = z
+  .discriminatedUnion('kind', [
+    z.object({kind: z.literal('git')}).strict(),
+    z
+      .object({
+        kind: z.literal('r2'),
+        /** R2 bucket name */
+        bucket: z.string().min(1),
+        /** S3-compatible API endpoint (CLI writes) */
+        endpoint: z.string().url(),
+        /** Public base the plugin's dataUrl points at — the client
+         * polls it, so https only (ADR-006 §2) */
+        publicBaseUrl: z
+          .string()
+          .url()
+          .refine(u => u.startsWith('https://'), {
+            message: 'publicBaseUrl must be https (clients poll it)',
+          }),
+      })
+      .strict(),
+  ])
+  .default({kind: 'git'});
+
 export const stentorosaurConfigSchema = z.object({
   owner: z.string().min(1),
   repo: z.string().min(1),
-  /** Data branch name (default status-data) */
+  /** Data branch name (default status-data) — Profile A/B */
   dataBranch: z.string().min(1).default('status-data'),
+  /** Data-plane profile (ADR-006); default git */
+  dataPlane: dataPlaneSchema,
   entities: z.array(configEntitySchema).min(1),
   incidents: z
     .object({

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -41,8 +41,8 @@ export const dataPlaneSchema = z
         kind: z.literal('r2'),
         /** R2 bucket name */
         bucket: z.string().min(1),
-        /** S3-compatible API endpoint (CLI writes) — https only:
-         * R2 credentials travel over it (Copilot PR #105 r=1) */
+        /** S3-compatible API endpoint (CLI writes) — https only (ADR-006 §2):
+         * R2 credentials travel over it */
         endpoint: z
           .string()
           .url()


### PR DESCRIPTION
Closes #98 (epic #97, ADR-006 §6)

One optional `dataPlane` block in `stentorosaur.config.js`; absence means the git data branch exactly as today (regression-tested against base configs).

- Discriminated **strict** union: `{kind: 'git'}` | `{kind: 'r2', bucket, endpoint, publicBaseUrl}`
- r2 fields required together, with zod field-path errors; `publicBaseUrl` https-only (clients poll it, ADR-006 §2)
- Stray r2 fields on the git profile are rejected — a typo'd profile fails loudly rather than silently staying on git
- CONFIGURATION.md documents the block, the §1 budget formula (`runs/day × (N+3) × 30`), and the custom-domain mandate

Core 72 green (9 new); probe 104 green; build + typecheck green.