### PR TITLE
feat: R2 storage backend behind the CLI writers (#99)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7954,6 +7954,12 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
@@ -24552,7 +24558,9 @@
       "license": "MIT",
       "dependencies": {
         "@stentorosaur/core": "^0.1.0",
-        "jiti": "^2.4.0"
+        "aws4fetch": "^1.0.20",
+        "jiti": "^2.4.0",
+        "zod": "^4.1.12"
       },
       "bin": {
         "stentorosaur": "bin/stentorosaur.cjs"

--- a/packages/probe/__tests__/r2-object-store.test.ts
+++ b/packages/probe/__tests__/r2-object-store.test.ts
@@ -1,0 +1,121 @@
+/**
+ * R2ObjectStore network-layer tests (Council PR #106 r=1: the concrete
+ * S3-API client had zero direct coverage). fetch is injected; every
+ * assertion runs against the REAL signing/pagination/error paths.
+ */
+
+import {PreconditionFailedError, R2ObjectStore} from '../src/object-store';
+
+function makeResponse(status: number, body = '', headers: Record<string, string> = {}): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    text: async () => body,
+    headers: {get: (name: string) => headers[name.toLowerCase()] ?? null},
+  } as unknown as Response;
+}
+
+interface Recorded {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+function makeStore(responder: (req: Recorded) => Response) {
+  const calls: Recorded[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    // aws4fetch signs into a Request object.
+    const request = input as Request;
+    const headers: Record<string, string> = {};
+    request.headers.forEach((v, k) => {
+      headers[k.toLowerCase()] = v;
+    });
+    const recorded: Recorded = {
+      url: request.url,
+      method: request.method,
+      headers,
+      body: request.body ? await request.text() : undefined,
+    };
+    calls.push(recorded);
+    return responder(recorded);
+  }) as unknown as typeof fetch;
+
+  const store = new R2ObjectStore({
+    endpoint: 'https://acc.r2.cloudflarestorage.com/', // trailing slash on purpose
+    bucket: 'status',
+    accessKeyId: 'AKID',
+    secretAccessKey: 'SECRET',
+    fetchImpl,
+  });
+  return {store, calls};
+}
+
+describe('R2ObjectStore (real client, injected fetch)', () => {
+  it('signs requests (SigV4 Authorization header) against normalized URLs', async () => {
+    const {store, calls} = makeStore(() => makeResponse(200, 'body', {etag: '"e1"'}));
+    const result = await store.get('status/v1/summary.json');
+    expect(result).toEqual({body: 'body', etag: '"e1"'});
+    expect(calls[0].url).toBe(
+      'https://acc.r2.cloudflarestorage.com/status/status/v1/summary.json'
+    );
+    expect(calls[0].headers.authorization).toMatch(/^AWS4-HMAC-SHA256/);
+    expect(calls[0].headers.authorization).toContain('AKID');
+  });
+
+  it('get returns null on 404 and throws on other errors', async () => {
+    const {store: notFound} = makeStore(() => makeResponse(404));
+    expect(await notFound.get('missing.json')).toBeNull();
+
+    const {store: broken} = makeStore(() => makeResponse(500));
+    await expect(broken.get('x.json')).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('put sends conditional headers and maps 412 to PreconditionFailedError', async () => {
+    const {store, calls} = makeStore(() => makeResponse(200, '', {etag: '"e2"'}));
+    await store.put('k.json', '{}', {ifMatch: '"e1"'});
+    expect(calls[0].method).toBe('PUT');
+    expect(calls[0].headers['if-match']).toBe('"e1"');
+    expect(calls[0].headers['content-type']).toBe('application/json');
+
+    const {store: contended} = makeStore(() => makeResponse(412));
+    await expect(contended.put('k.json', '{}', {ifMatch: '"e1"'})).rejects.toThrow(
+      PreconditionFailedError
+    );
+  });
+
+  it('put sends if-none-match for immutable creates', async () => {
+    const {store, calls} = makeStore(() => makeResponse(200, '', {etag: '"e3"'}));
+    await store.put('batch.json', '[]', {ifNoneMatch: '*'});
+    expect(calls[0].headers['if-none-match']).toBe('*');
+  });
+
+  it('list paginates via continuation tokens and decodes XML entities', async () => {
+    let page = 0;
+    const {store, calls} = makeStore(() => {
+      page++;
+      if (page === 1) {
+        return makeResponse(
+          200,
+          '<ListBucketResult><Key>a.json</Key><Key>b&amp;c.json</Key>' +
+            '<NextContinuationToken>tok1</NextContinuationToken></ListBucketResult>'
+        );
+      }
+      return makeResponse(200, '<ListBucketResult><Key>d.json</Key></ListBucketResult>');
+    });
+    const keys = await store.list('status/v1/readings/');
+    expect(keys).toEqual(['a.json', 'b&c.json', 'd.json']);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toContain('list-type=2');
+    expect(calls[0].url).toContain('prefix=status%2Fv1%2Freadings%2F');
+    expect(calls[1].url).toContain('continuation-token=tok1');
+  });
+
+  it('delete tolerates 404 and throws on real errors', async () => {
+    const {store} = makeStore(() => makeResponse(404));
+    await expect(store.delete('gone.json')).resolves.toBeUndefined();
+
+    const {store: broken} = makeStore(() => makeResponse(500));
+    await expect(broken.delete('x.json')).rejects.toThrow(/HTTP 500/);
+  });
+});

--- a/packages/probe/__tests__/r2-writer.test.ts
+++ b/packages/probe/__tests__/r2-writer.test.ts
@@ -193,6 +193,28 @@ describe('regenerateDerivedR2 — §3 write-order consistency (council condition
     expect(api.days.length).toBeGreaterThanOrEqual(2); // both days present
   });
 
+  it('a corrupt batch object never crashes the regenerator (Council r=1)', async () => {
+    const store = new MemoryObjectStore();
+    await seedBatch(store, [reading('api', 1000)]);
+    await store.put('status/v1/readings/2026-07-15T11-00-00-000Z-bad.json', 'NOT JSON');
+    const warnings: string[] = [];
+    await regenerateDerivedR2(store, {...REGEN_OPTS, onWarn: w => warnings.push(w)});
+    const summary = parseSummary(JSON.parse((await store.get('status/v1/summary.json'))!.body));
+    expect(summary.entities.find(e => e.name === 'api')!.status).toBe('up');
+    expect(warnings.some(w => /unparseable batch/.test(w))).toBe(true);
+  });
+
+  it('skips batch objects older than the rollup window without fetching them', async () => {
+    const store = new MemoryObjectStore();
+    await seedBatch(store, [reading('api', 1000)]);
+    // A compaction-orphaned stray from far outside the window:
+    await store.put('status/v1/readings/2020-01-01T00-00-00-000Z-old.json', '[]');
+    store.ops.length = 0;
+    await regenerateDerivedR2(store, REGEN_OPTS);
+    const gets = store.ops.filter(o => o.op === 'get').map(o => o.key);
+    expect(gets).not.toContain('status/v1/readings/2020-01-01T00-00-00-000Z-old.json');
+  });
+
   it('dedupes readings present in BOTH an archive and an uncompacted batch (compaction window)', async () => {
     const store = new MemoryObjectStore();
     const r = reading('api', 1000);

--- a/packages/probe/__tests__/r2-writer.test.ts
+++ b/packages/probe/__tests__/r2-writer.test.ts
@@ -1,0 +1,302 @@
+/**
+ * R2 data-plane writer tests (ADR-006 §1/§3; epic #97 ticket #99).
+ *
+ * The load-bearing assertions are the COUNCIL CONDITIONS:
+ * - write-order consistency: summary.json is written LAST (commit
+ *   point) — a reader polling between writes never sees a summary
+ *   newer than its inputs
+ * - If-Match retry on the summary commit converges under contention
+ * - content-hash guard skips unchanged entity-detail writes (class-A
+ *   budget, condition 4)
+ */
+
+import {parseSummary} from '@stentorosaur/core';
+import type {CompactReading} from '@stentorosaur/core';
+import {MemoryObjectStore, PreconditionFailedError, normalizeBaseUrl} from '../src/object-store';
+import {regenerateDerivedR2, reRenderFromRawR2, writeReadingsBatch} from '../src/r2-plane';
+
+const NOW = Date.parse('2026-07-15T12:00:00.000Z');
+const GENERATED_AT = new Date(NOW).toISOString();
+const ENTITIES = [
+  {name: 'api', type: 'system' as const},
+  {name: 'web', type: 'system' as const},
+];
+
+function reading(svc: string, offsetMs: number, state: 'up' | 'down' = 'up'): CompactReading {
+  return {t: NOW - offsetMs, svc, state, code: state === 'up' ? 200 : 500, lat: 42};
+}
+
+const REGEN_OPTS = {
+  generatedAt: GENERATED_AT,
+  generatedBy: 'test',
+  entities: ENTITIES,
+  siteTitle: 'T',
+  siteUrl: 'https://t.example.com',
+};
+
+async function seedBatch(store: MemoryObjectStore, readings: CompactReading[], runId = 'run1') {
+  return writeReadingsBatch(store, readings, GENERATED_AT, runId);
+}
+
+describe('writeReadingsBatch', () => {
+  it('writes one immutable batch object per run', async () => {
+    const store = new MemoryObjectStore();
+    const key = await seedBatch(store, [reading('api', 1000)]);
+    expect(key).toMatch(/^status\/v1\/readings\//);
+    // Immutable: same key cannot be overwritten (ifNoneMatch: '*').
+    await expect(
+      store.put(key, '[]', {ifNoneMatch: '*'})
+    ).rejects.toThrow(PreconditionFailedError);
+  });
+});
+
+describe('regenerateDerivedR2 — §3 write-order consistency (council condition 1)', () => {
+  it('writes derived objects with summary.json strictly LAST', async () => {
+    const store = new MemoryObjectStore();
+    await seedBatch(store, [reading('api', 1000), reading('web', 900)]);
+    store.ops.length = 0;
+
+    await regenerateDerivedR2(store, REGEN_OPTS);
+
+    const puts = store.ops.filter(o => o.op === 'put').map(o => o.key);
+    expect(puts[puts.length - 1]).toBe('status/v1/summary.json');
+    expect(puts).toEqual(
+      expect.arrayContaining([
+        'status/v1/entities/api.json',
+        'status/v1/entities/web.json',
+        'status/v1/incidents.atom',
+      ])
+    );
+    // Every non-summary derived write precedes the summary.
+    const summaryIndex = puts.indexOf('status/v1/summary.json');
+    expect(summaryIndex).toBe(puts.length - 1);
+  });
+
+  it('produces a schema-valid summary from batches + inputs', async () => {
+    const store = new MemoryObjectStore();
+    await seedBatch(store, [reading('api', 1000), reading('web', 900, 'down')]);
+    await regenerateDerivedR2(store, REGEN_OPTS);
+
+    const summary = parseSummary(JSON.parse((await store.get('status/v1/summary.json'))!.body));
+    expect(summary.entities.map(e => `${e.name}:${e.status}`)).toEqual(['api:up', 'web:down']);
+    expect((await store.get('status/v1/incidents.atom'))!.body).toContain('<feed');
+  });
+
+  it('retries the summary commit on precondition failure and converges', async () => {
+    const store = new MemoryObjectStore();
+    await seedBatch(store, [reading('api', 1000)]);
+    await regenerateDerivedR2(store, REGEN_OPTS); // summary now exists
+
+    // Interleave a competing writer: on the FIRST summary read, mutate
+    // the summary behind the regenerator's back so its If-Match loses.
+    const originalGet = store.get.bind(store);
+    let sabotaged = false;
+    jest.spyOn(store, 'get').mockImplementation(async key => {
+      const result = await originalGet(key);
+      if (key === 'status/v1/summary.json' && !sabotaged) {
+        sabotaged = true;
+        await store.put('status/v1/summary.json', result!.body); // bumps etag
+      }
+      return result;
+    });
+
+    const outcome = await regenerateDerivedR2(store, REGEN_OPTS);
+    expect(outcome.attempts).toBe(2);
+    parseSummary(JSON.parse((await originalGet('status/v1/summary.json'))!.body));
+  });
+
+  it('gives up loudly after maxRetries under persistent contention', async () => {
+    const store = new MemoryObjectStore();
+    await seedBatch(store, [reading('api', 1000)]);
+    await regenerateDerivedR2(store, REGEN_OPTS);
+
+    const originalGet = store.get.bind(store);
+    jest.spyOn(store, 'get').mockImplementation(async key => {
+      const result = await originalGet(key);
+      if (key === 'status/v1/summary.json') {
+        await store.put('status/v1/summary.json', result!.body); // always bump
+      }
+      return result;
+    });
+
+    await expect(
+      regenerateDerivedR2(store, {...REGEN_OPTS, maxRetries: 2})
+    ).rejects.toThrow(/persistent write contention/);
+  });
+
+  it('skips unchanged entity-detail writes (council condition 4)', async () => {
+    const store = new MemoryObjectStore();
+    await seedBatch(store, [reading('api', 1000), reading('web', 900)]);
+    await regenerateDerivedR2(store, REGEN_OPTS);
+
+    // Second regenerate over IDENTICAL inputs: entity payloads unchanged.
+    store.ops.length = 0;
+    const outcome = await regenerateDerivedR2(store, {
+      ...REGEN_OPTS,
+      generatedAt: new Date(NOW + 60_000).toISOString(),
+    });
+
+    expect(outcome.entityWritesSkipped).toBe(2);
+    const puts = store.ops.filter(o => o.op === 'put').map(o => o.key);
+    expect(puts).not.toContain('status/v1/entities/api.json');
+    expect(puts).not.toContain('status/v1/entities/web.json');
+    // Summary still commits (generatedAt changed).
+    expect(puts[puts.length - 1]).toBe('status/v1/summary.json');
+  });
+
+  it('folds day archives AND uncompacted batches into the rollups', async () => {
+    const store = new MemoryObjectStore();
+    // Yesterday's compacted archive:
+    const yesterday = new Date(NOW - 24 * 3600_000).toISOString().split('T')[0];
+    const [y, m] = yesterday.split('-');
+    await store.put(
+      `status/v1/archives/${y}/${m}/history-${yesterday}.jsonl`,
+      [reading('api', 24 * 3600_000 + 1000), reading('api', 24 * 3600_000 + 2000)]
+        .map(r => JSON.stringify(r))
+        .join('\n')
+    );
+    // Today's uncompacted batch:
+    await seedBatch(store, [reading('api', 1000)]);
+
+    await regenerateDerivedR2(store, REGEN_OPTS);
+    const summary = parseSummary(JSON.parse((await store.get('status/v1/summary.json'))!.body));
+    const api = summary.entities.find(e => e.name === 'api')!;
+    expect(api.days.length).toBeGreaterThanOrEqual(2); // both days present
+  });
+
+  it('reads incident/maintenance inputs and reflects them in the summary', async () => {
+    const store = new MemoryObjectStore();
+    await seedBatch(store, [reading('api', 1000)]);
+    await store.put(
+      'status/v1/inputs/incidents.json',
+      JSON.stringify([
+        {
+          issueNumber: 5,
+          title: 'API degraded',
+          severity: 'major',
+          status: 'open',
+          entities: ['api'],
+          createdAt: GENERATED_AT,
+          closedAt: null,
+          bodyHtml: '<p>x</p>',
+        },
+      ])
+    );
+    await regenerateDerivedR2(store, REGEN_OPTS);
+    const summary = parseSummary(JSON.parse((await store.get('status/v1/summary.json'))!.body));
+    expect(summary.entities.find(e => e.name === 'api')!.status).toBe('degraded');
+    expect(summary.incidents.open).toHaveLength(1);
+  });
+});
+
+describe('reRenderFromRawR2 (§7 runbook on r2)', () => {
+  it('re-renders bodies from raw/ with the current sanitizer', async () => {
+    const store = new MemoryObjectStore();
+    await store.put(
+      'status/v1/raw/11.json',
+      JSON.stringify({
+        schemaVersion: 1,
+        issueNumber: 11,
+        updatedAt: GENERATED_AT,
+        bodyMarkdown: '**fresh** body',
+      })
+    );
+    await store.put(
+      'status/v1/inputs/incidents.json',
+      JSON.stringify([
+        {
+          issueNumber: 11,
+          title: 'X',
+          severity: 'minor',
+          status: 'open',
+          entities: [],
+          createdAt: GENERATED_AT,
+          closedAt: null,
+          bodyHtml: '<p>STALE</p>',
+        },
+      ])
+    );
+    const counts = await reRenderFromRawR2(store, new Date(NOW));
+    expect(counts.incidents).toBe(1);
+    const incidents = JSON.parse((await store.get('status/v1/inputs/incidents.json'))!.body);
+    expect(incidents[0].bodyHtml).toContain('<strong>fresh</strong>');
+  });
+});
+
+describe('CLI routing for the r2 data plane', () => {
+  const R2_CONFIG = `module.exports = {
+    owner: 'o', repo: 'r',
+    entities: [{name: 'api', type: 'system', probe: {url: 'http://127.0.0.1:1/x'}}],
+    dataPlane: {kind: 'r2', bucket: 'b', endpoint: 'https://a.r2.cloudflarestorage.com', publicBaseUrl: 'https://s.example.com'},
+  };`;
+
+  it('fails with an actionable error when R2 credentials are missing', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const {main} = await import('../src/cli');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'r2cli-'));
+    const prevId = process.env.R2_ACCESS_KEY_ID;
+    const prevSecret = process.env.R2_SECRET_ACCESS_KEY;
+    delete process.env.R2_ACCESS_KEY_ID;
+    delete process.env.R2_SECRET_ACCESS_KEY;
+    try {
+      fs.writeFileSync(path.join(tmp, 'stentorosaur.config.js'), R2_CONFIG);
+      const code = await main(['probe', '--config', tmp, '--workdir', tmp]);
+      expect(code).toBe(1); // errors mention the env vars, never crash
+    } finally {
+      if (prevId) process.env.R2_ACCESS_KEY_ID = prevId;
+      if (prevSecret) process.env.R2_SECRET_ACCESS_KEY = prevSecret;
+      fs.rmSync(tmp, {recursive: true, force: true});
+    }
+  });
+
+  it('probe on the r2 plane runs the full batch → regenerate cycle (injected store)', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const http = await import('node:http');
+    const {main} = await import('../src/cli');
+    const cliModule = await import('../src/cli');
+    const store = new MemoryObjectStore();
+    cliModule.setObjectStoreFactory(() => store);
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'r2cli-'));
+    const server = http.createServer((_q, r) => {
+      r.writeHead(200);
+      r.end('ok');
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as {port: number}).port;
+    try {
+      fs.writeFileSync(
+        path.join(tmp, 'stentorosaur.config.js'),
+        `module.exports = {
+          owner: 'o', repo: 'r',
+          entities: [{name: 'api', type: 'system', probe: {url: 'http://127.0.0.1:${port}/health'}}],
+          dataPlane: {kind: 'r2', bucket: 'b', endpoint: 'https://a.r2.cloudflarestorage.com', publicBaseUrl: 'https://s.example.com'},
+        };`
+      );
+      const code = await main(['probe', '--config', tmp, '--workdir', tmp]);
+      expect(code).toBe(0);
+      const summary = parseSummary(JSON.parse((await store.get('status/v1/summary.json'))!.body));
+      expect(summary.entities[0]).toMatchObject({name: 'api', status: 'up'});
+      expect(store.keys().some(k => k.startsWith('status/v1/readings/'))).toBe(true);
+      // Nothing written to the local filesystem — this plane is git-free.
+      expect(fs.existsSync(path.join(tmp, 'status'))).toBe(false);
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+      fs.rmSync(tmp, {recursive: true, force: true});
+    }
+  });
+});
+
+describe('normalizeBaseUrl (Council PR #105 note)', () => {
+  it('strips trailing slashes so URL joins are unambiguous', () => {
+    expect(normalizeBaseUrl('https://x.r2.cloudflarestorage.com/')).toBe(
+      'https://x.r2.cloudflarestorage.com'
+    );
+    expect(normalizeBaseUrl('https://x.r2.cloudflarestorage.com')).toBe(
+      'https://x.r2.cloudflarestorage.com'
+    );
+  });
+});

--- a/packages/probe/__tests__/r2-writer.test.ts
+++ b/packages/probe/__tests__/r2-writer.test.ts
@@ -193,6 +193,21 @@ describe('regenerateDerivedR2 — §3 write-order consistency (council condition
     expect(api.days.length).toBeGreaterThanOrEqual(2); // both days present
   });
 
+  it('dedupes readings present in BOTH an archive and an uncompacted batch (compaction window)', async () => {
+    const store = new MemoryObjectStore();
+    const r = reading('api', 1000);
+    const today = new Date(NOW).toISOString().split('T')[0];
+    const [y, m] = today.split('-');
+    // Same reading in the day archive AND still in a batch (compaction
+    // wrote the archive but hasn't deleted the batch yet).
+    await store.put(`status/v1/archives/${y}/${m}/history-${today}.jsonl`, JSON.stringify(r));
+    await seedBatch(store, [r]);
+
+    await regenerateDerivedR2(store, REGEN_OPTS);
+    const detail = JSON.parse((await store.get('status/v1/entities/api.json'))!.body);
+    expect(detail.readings).toHaveLength(1); // counted once, not twice
+  });
+
   it('reads incident/maintenance inputs and reflects them in the summary', async () => {
     const store = new MemoryObjectStore();
     await seedBatch(store, [reading('api', 1000)]);

--- a/packages/probe/__tests__/r2-writer.test.ts
+++ b/packages/probe/__tests__/r2-writer.test.ts
@@ -144,6 +144,35 @@ describe('regenerateDerivedR2 — §3 write-order consistency (council condition
     expect(puts[puts.length - 1]).toBe('status/v1/summary.json');
   });
 
+  it('entityWritesSkipped reflects only the winning attempt, not accumulated across retries', async () => {
+    const store = new MemoryObjectStore();
+    await seedBatch(store, [reading('api', 1000), reading('web', 900)]);
+    await regenerateDerivedR2(store, REGEN_OPTS); // first run writes entities
+
+    // Second run: entities are skippable (unchanged readings). We force one
+    // retry by bumping the summary etag behind the regenerator's back.
+    const originalGet = store.get.bind(store);
+    let sabotaged = false;
+    jest.spyOn(store, 'get').mockImplementation(async key => {
+      const result = await originalGet(key);
+      if (key === 'status/v1/summary.json' && !sabotaged) {
+        sabotaged = true;
+        await store.put('status/v1/summary.json', result!.body); // bumps etag, forces retry
+      }
+      return result;
+    });
+
+    const outcome = await regenerateDerivedR2(store, {
+      ...REGEN_OPTS,
+      generatedAt: new Date(NOW + 60_000).toISOString(),
+    });
+
+    // Two attempts fired; entities were skipped in each. The count must be
+    // 2 (one skip per entity on the winning attempt), not 4.
+    expect(outcome.attempts).toBe(2);
+    expect(outcome.entityWritesSkipped).toBe(2);
+  });
+
   it('folds day archives AND uncompacted batches into the rollups', async () => {
     const store = new MemoryObjectStore();
     // Yesterday's compacted archive:

--- a/packages/probe/__tests__/r2-writer.test.ts
+++ b/packages/probe/__tests__/r2-writer.test.ts
@@ -356,6 +356,29 @@ describe('CLI routing for the r2 data plane', () => {
   });
 });
 
+describe('reRenderFromRawR2 hardening (Council r=2)', () => {
+  it('aborts with an actionable error on malformed inputs instead of wiping them', async () => {
+    const store = new MemoryObjectStore();
+    await store.put('status/v1/inputs/incidents.json', 'NOT JSON');
+    await expect(reRenderFromRawR2(store, new Date(NOW))).rejects.toThrow(/refusing to re-render/);
+    // The corrupt object is untouched — nothing was rewritten.
+    expect((await store.get('status/v1/inputs/incidents.json'))!.body).toBe('NOT JSON');
+  });
+
+  it('writes maintenance before incidents (incidents = runbook commit point)', async () => {
+    const store = new MemoryObjectStore();
+    await store.put('status/v1/inputs/incidents.json', '[]');
+    await store.put('status/v1/inputs/maintenance.json', '[]');
+    store.ops.length = 0;
+    await reRenderFromRawR2(store, new Date(NOW));
+    const puts = store.ops.filter(o => o.op === 'put').map(o => o.key);
+    expect(puts).toEqual([
+      'status/v1/inputs/maintenance.json',
+      'status/v1/inputs/incidents.json',
+    ]);
+  });
+});
+
 describe('normalizeBaseUrl (Council PR #105 note)', () => {
   it('strips trailing slashes so URL joins are unambiguous', () => {
     expect(normalizeBaseUrl('https://x.r2.cloudflarestorage.com/')).toBe(

--- a/packages/probe/package.json
+++ b/packages/probe/package.json
@@ -40,7 +40,9 @@
   },
   "dependencies": {
     "@stentorosaur/core": "^0.1.0",
-    "jiti": "^2.4.0"
+    "jiti": "^2.4.0",
+    "aws4fetch": "^1.0.20",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/packages/probe/src/cli.ts
+++ b/packages/probe/src/cli.ts
@@ -29,7 +29,7 @@ import {migrateHistoricalData, planMigration} from './migrate';
 import type {MigrationReport} from './migrate';
 import {R2ObjectStore} from './object-store';
 import type {ObjectStore} from './object-store';
-import {regenerateDerivedR2, reRenderFromRawR2, writeReadingsBatch} from './r2-plane';
+import {V1, regenerateDerivedR2, reRenderFromRawR2, writeReadingsBatch} from './r2-plane';
 import {parseProbeDispatch, parseSummary} from '@stentorosaur/core';
 import type {CompactReading, StentorosaurConfig} from '@stentorosaur/core';
 
@@ -106,8 +106,9 @@ function regenOptions(config: StentorosaurConfig, generatedAt: string) {
   };
 }
 
-/** Test seam: cli tests inject a MemoryObjectStore here. */
-export let makeObjectStore = (config: StentorosaurConfig): ObjectStore => {
+/** Test seam: module-private factory, swapped only via
+ * setObjectStoreFactory (Copilot PR #106 r=1 — no exported mutable let). */
+let objectStoreFactory = (config: StentorosaurConfig): ObjectStore => {
   const plane = config.dataPlane;
   if (plane.kind !== 'r2') throw new Error('makeObjectStore called for a non-r2 data plane');
   const accessKeyId = process.env.R2_ACCESS_KEY_ID;
@@ -125,8 +126,8 @@ export let makeObjectStore = (config: StentorosaurConfig): ObjectStore => {
   });
 };
 
-export function setObjectStoreFactory(factory: typeof makeObjectStore): void {
-  makeObjectStore = factory;
+export function setObjectStoreFactory(factory: typeof objectStoreFactory): void {
+  objectStoreFactory = factory;
 }
 
 /** The r2-plane counterpart of withDataBranch: one clock read, batch
@@ -135,7 +136,7 @@ async function withR2Plane(
   config: StentorosaurConfig,
   writeInputs: (store: ObjectStore, generatedAt: string) => Promise<void>
 ): Promise<void> {
-  const store = makeObjectStore(config);
+  const store = objectStoreFactory(config);
   const generatedAt = new Date().toISOString();
   await writeInputs(store, generatedAt);
   const result = await regenerateDerivedR2(store, {
@@ -350,10 +351,10 @@ async function cmdUpdateIncidents(options: CliOptions): Promise<number> {
         now: new Date(generatedAt),
       });
       for (const raw of transformed.raws) {
-        await store.put(`status/v1/raw/${raw.issueNumber}.json`, JSON.stringify(raw));
+        await store.put(`${V1}/raw/${raw.issueNumber}.json`, JSON.stringify(raw));
       }
-      await store.put('status/v1/inputs/incidents.json', JSON.stringify(transformed.incidents));
-      await store.put('status/v1/inputs/maintenance.json', JSON.stringify(transformed.maintenance));
+      await store.put(`${V1}/inputs/incidents.json`, JSON.stringify(transformed.incidents));
+      await store.put(`${V1}/inputs/maintenance.json`, JSON.stringify(transformed.maintenance));
       counts = {
         incidents: transformed.incidents.length,
         maintenance: transformed.maintenance.length,

--- a/packages/probe/src/cli.ts
+++ b/packages/probe/src/cli.ts
@@ -24,9 +24,12 @@ import type {CheckTarget} from './check';
 import {pushWithRegenerateRetry} from './git-writer';
 import {regenerateDerived} from './regenerate';
 import {reRenderFromRaw} from './regenerate-from-raw';
-import {fetchStatusIssues, writeIssueInputs} from './update-incidents';
+import {fetchStatusIssues, transformIssueInputs, writeIssueInputs} from './update-incidents';
 import {migrateHistoricalData, planMigration} from './migrate';
 import type {MigrationReport} from './migrate';
+import {R2ObjectStore} from './object-store';
+import type {ObjectStore} from './object-store';
+import {regenerateDerivedR2, reRenderFromRawR2, writeReadingsBatch} from './r2-plane';
 import {parseProbeDispatch, parseSummary} from '@stentorosaur/core';
 import type {CompactReading, StentorosaurConfig} from '@stentorosaur/core';
 
@@ -101,6 +104,55 @@ function regenOptions(config: StentorosaurConfig, generatedAt: string) {
     siteTitle: config.site.title,
     siteUrl: config.site.url ?? `https://github.com/${config.owner}/${config.repo}`,
   };
+}
+
+/** Test seam: cli tests inject a MemoryObjectStore here. */
+export let makeObjectStore = (config: StentorosaurConfig): ObjectStore => {
+  const plane = config.dataPlane;
+  if (plane.kind !== 'r2') throw new Error('makeObjectStore called for a non-r2 data plane');
+  const accessKeyId = process.env.R2_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+  if (!accessKeyId || !secretAccessKey) {
+    throw new Error(
+      'dataPlane.kind is r2 but R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY are not set'
+    );
+  }
+  return new R2ObjectStore({
+    endpoint: plane.endpoint,
+    bucket: plane.bucket,
+    accessKeyId,
+    secretAccessKey,
+  });
+};
+
+export function setObjectStoreFactory(factory: typeof makeObjectStore): void {
+  makeObjectStore = factory;
+}
+
+/** The r2-plane counterpart of withDataBranch: one clock read, batch
+ * write, then the §3 ordered regenerate with summary-last commit. */
+async function withR2Plane(
+  config: StentorosaurConfig,
+  writeInputs: (store: ObjectStore, generatedAt: string) => Promise<void>
+): Promise<void> {
+  const store = makeObjectStore(config);
+  const generatedAt = new Date().toISOString();
+  await writeInputs(store, generatedAt);
+  const result = await regenerateDerivedR2(store, {
+    generatedAt,
+    generatedBy: 'stentorosaur-cli',
+    entities: config.entities.map(({name, type, displayName}) => ({
+      name,
+      type,
+      ...(displayName ? {displayName} : {}),
+    })),
+    siteTitle: config.site.title,
+    siteUrl: config.site.url ?? `https://github.com/${config.owner}/${config.repo}`,
+    onWarn: message => console.warn(`  ⚠ ${message}`),
+  });
+  if (result.attempts > 1) {
+    console.log(`  summary committed after ${result.attempts} attempts`);
+  }
 }
 
 const CONFIG_TEMPLATE = `// stentorosaur.config.js — single source of truth for the probe, the
@@ -258,9 +310,15 @@ async function cmdProbe(options: CliOptions): Promise<number> {
   }
   const readings = await runChecks(targets);
 
-  await withDataBranch(options, config, `probe: ${readings.length} checks`, async (dir, generatedAt) => {
-    writeReadings(dir, readings, generatedAt);
-  });
+  if (config.dataPlane.kind === 'r2') {
+    await withR2Plane(config, async (store, generatedAt) => {
+      await writeReadingsBatch(store, readings, generatedAt, Math.random().toString(36).slice(2, 8));
+    });
+  } else {
+    await withDataBranch(options, config, `probe: ${readings.length} checks`, async (dir, generatedAt) => {
+      writeReadings(dir, readings, generatedAt);
+    });
+  }
   for (const reading of readings) {
     console.log(`  ${reading.state === 'up' ? '✓' : '✗'} ${reading.svc}: ${reading.state} (${reading.code} in ${reading.lat}ms)`);
   }
@@ -283,20 +341,48 @@ async function cmdUpdateIncidents(options: CliOptions): Promise<number> {
   });
 
   let counts = {incidents: 0, maintenance: 0, skipped: 0};
-  await withDataBranch(options, config, `issues: sync ${issues.length} issues`, async (dir, generatedAt) => {
-    counts = writeIssueInputs(dir, issues, {
-      entities: config.entities,
-      maintenanceLabels: config.incidents.maintenanceLabels,
-      labelScheme: config.labelScheme,
-      now: new Date(generatedAt),
+  if (config.dataPlane.kind === 'r2') {
+    await withR2Plane(config, async (store, generatedAt) => {
+      const transformed = transformIssueInputs(issues, {
+        entities: config.entities,
+        maintenanceLabels: config.incidents.maintenanceLabels,
+        labelScheme: config.labelScheme,
+        now: new Date(generatedAt),
+      });
+      for (const raw of transformed.raws) {
+        await store.put(`status/v1/raw/${raw.issueNumber}.json`, JSON.stringify(raw));
+      }
+      await store.put('status/v1/inputs/incidents.json', JSON.stringify(transformed.incidents));
+      await store.put('status/v1/inputs/maintenance.json', JSON.stringify(transformed.maintenance));
+      counts = {
+        incidents: transformed.incidents.length,
+        maintenance: transformed.maintenance.length,
+        skipped: transformed.skipped,
+      };
     });
-  });
+  } else {
+    await withDataBranch(options, config, `issues: sync ${issues.length} issues`, async (dir, generatedAt) => {
+      counts = writeIssueInputs(dir, issues, {
+        entities: config.entities,
+        maintenanceLabels: config.incidents.maintenanceLabels,
+        labelScheme: config.labelScheme,
+        now: new Date(generatedAt),
+      });
+    });
+  }
   console.log(`synced ${counts.incidents} incidents, ${counts.maintenance} maintenance windows (${counts.skipped} skipped)`);
   return 0;
 }
 
 async function cmdRegenerate(options: CliOptions): Promise<number> {
   const config = await loadConfig(options.config);
+  if (config.dataPlane.kind === 'r2') {
+    await withR2Plane(config, async (store, generatedAt) => {
+      const counts = await reRenderFromRawR2(store, new Date(generatedAt));
+      console.log(`re-rendered ${counts.incidents} incident and ${counts.maintenance} maintenance bodies from raw/`);
+    });
+    return 0;
+  }
   await withDataBranch(options, config, 'regenerate: re-render from raw provenance (§7)', async (dir, generatedAt) => {
     const counts = reRenderFromRaw(dir, new Date(generatedAt));
     console.log(`re-rendered ${counts.incidents} incident and ${counts.maintenance} maintenance bodies from raw/`);

--- a/packages/probe/src/index.ts
+++ b/packages/probe/src/index.ts
@@ -15,4 +15,6 @@ export * from './compact';
 export * from './config-loader';
 export * from './regenerate-from-raw';
 export * from './migrate';
+export * from './object-store';
+export * from './r2-plane';
 export * from './cli';

--- a/packages/probe/src/object-store.ts
+++ b/packages/probe/src/object-store.ts
@@ -1,0 +1,174 @@
+/**
+ * Object-store abstraction for the R2 data plane (ADR-006 §1/§3;
+ * epic #97 ticket #99).
+ *
+ * The R2 implementation speaks the S3-compatible API via aws4fetch
+ * (SigV4 over fetch — the same client works in Node ≥20 and Cloudflare
+ * Workers). Tests use MemoryObjectStore; the write pipeline in
+ * r2-plane.ts is written against the interface, never a concrete store.
+ */
+
+import {AwsClient} from 'aws4fetch';
+
+export interface PutOptions {
+  /** Conditional put: only if the current ETag matches (ADR-006 §3) */
+  ifMatch?: string;
+  /** Conditional create: only if the object does NOT exist */
+  ifNoneMatch?: '*';
+  contentType?: string;
+}
+
+export interface StoredObject {
+  body: string;
+  etag: string;
+}
+
+/** Thrown when a conditional put loses the race (HTTP 412). */
+export class PreconditionFailedError extends Error {
+  constructor(key: string) {
+    super(`precondition failed for ${key}`);
+    this.name = 'PreconditionFailedError';
+  }
+}
+
+export interface ObjectStore {
+  get(key: string): Promise<StoredObject | null>;
+  put(key: string, body: string, options?: PutOptions): Promise<{etag: string}>;
+  /** All keys under a prefix (paginated internally) */
+  list(prefix: string): Promise<string[]>;
+  delete(key: string): Promise<void>;
+}
+
+/** Strip trailing slashes — endpoint/publicBaseUrl are not normalized
+ * at the schema (Council PR #105 note); every join happens here. */
+export function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+export interface R2StoreOptions {
+  /** S3-compatible API endpoint, e.g. https://<account>.r2.cloudflarestorage.com */
+  endpoint: string;
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  /** Injected for tests */
+  fetchImpl?: typeof fetch;
+}
+
+export class R2ObjectStore implements ObjectStore {
+  private readonly client: AwsClient;
+  private readonly base: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: R2StoreOptions) {
+    this.client = new AwsClient({
+      accessKeyId: options.accessKeyId,
+      secretAccessKey: options.secretAccessKey,
+      service: 's3',
+      region: 'auto',
+    });
+    this.base = `${normalizeBaseUrl(options.endpoint)}/${options.bucket}`;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  private url(key: string): string {
+    return `${this.base}/${key.replace(/^\/+/, '')}`;
+  }
+
+  private async signedFetch(url: string, init: RequestInit): Promise<Response> {
+    const signed = await this.client.sign(url, init);
+    return this.fetchImpl(signed);
+  }
+
+  async get(key: string): Promise<StoredObject | null> {
+    const response = await this.signedFetch(this.url(key), {method: 'GET'});
+    if (response.status === 404) return null;
+    if (!response.ok) throw new Error(`GET ${key}: HTTP ${response.status}`);
+    return {
+      body: await response.text(),
+      etag: response.headers.get('etag') ?? '',
+    };
+  }
+
+  async put(key: string, body: string, options: PutOptions = {}): Promise<{etag: string}> {
+    const headers: Record<string, string> = {
+      'content-type': options.contentType ?? 'application/json',
+    };
+    if (options.ifMatch) headers['if-match'] = options.ifMatch;
+    if (options.ifNoneMatch) headers['if-none-match'] = options.ifNoneMatch;
+    const response = await this.signedFetch(this.url(key), {method: 'PUT', headers, body});
+    if (response.status === 412) throw new PreconditionFailedError(key);
+    if (!response.ok) throw new Error(`PUT ${key}: HTTP ${response.status}`);
+    return {etag: response.headers.get('etag') ?? ''};
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    const keys: string[] = [];
+    let token: string | undefined;
+    do {
+      const params = new URLSearchParams({'list-type': '2', prefix});
+      if (token) params.set('continuation-token', token);
+      const response = await this.signedFetch(`${this.base}?${params}`, {method: 'GET'});
+      if (!response.ok) throw new Error(`LIST ${prefix}: HTTP ${response.status}`);
+      const xml = await response.text();
+      for (const match of xml.matchAll(/<Key>([^<]+)<\/Key>/g)) {
+        keys.push(match[1]);
+      }
+      const next = xml.match(/<NextContinuationToken>([^<]+)<\/NextContinuationToken>/);
+      token = next?.[1];
+    } while (token);
+    return keys;
+  }
+
+  async delete(key: string): Promise<void> {
+    const response = await this.signedFetch(this.url(key), {method: 'DELETE'});
+    if (!response.ok && response.status !== 404) {
+      throw new Error(`DELETE ${key}: HTTP ${response.status}`);
+    }
+  }
+}
+
+/**
+ * In-memory store for tests: same semantics incl. ETags and
+ * conditional puts, plus an operation log so tests can assert WRITE
+ * ORDER (the ADR-006 §3 consistency model is an ordering contract).
+ */
+export class MemoryObjectStore implements ObjectStore {
+  private readonly objects = new Map<string, StoredObject>();
+  readonly ops: Array<{op: 'get' | 'put' | 'list' | 'delete'; key: string}> = [];
+  private etagCounter = 0;
+
+  async get(key: string): Promise<StoredObject | null> {
+    this.ops.push({op: 'get', key});
+    return this.objects.get(key) ?? null;
+  }
+
+  async put(key: string, body: string, options: PutOptions = {}): Promise<{etag: string}> {
+    this.ops.push({op: 'put', key});
+    const existing = this.objects.get(key);
+    if (options.ifMatch && (!existing || existing.etag !== options.ifMatch)) {
+      throw new PreconditionFailedError(key);
+    }
+    if (options.ifNoneMatch === '*' && existing) {
+      throw new PreconditionFailedError(key);
+    }
+    const etag = `"m${++this.etagCounter}"`;
+    this.objects.set(key, {body, etag});
+    return {etag};
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    this.ops.push({op: 'list', key: prefix});
+    return [...this.objects.keys()].filter(k => k.startsWith(prefix)).sort();
+  }
+
+  async delete(key: string): Promise<void> {
+    this.ops.push({op: 'delete', key});
+    this.objects.delete(key);
+  }
+
+  /** Test helper: keys currently stored. */
+  keys(): string[] {
+    return [...this.objects.keys()].sort();
+  }
+}

--- a/packages/probe/src/object-store.ts
+++ b/packages/probe/src/object-store.ts
@@ -39,6 +39,18 @@ export interface ObjectStore {
   delete(key: string): Promise<void>;
 }
 
+/** Minimal XML entity decoding for S3 ListObjects keys — our keys are
+ * generated ASCII, but a foreign object in the bucket must not corrupt
+ * the listing (Council PR #106 r=1). */
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
 /** Strip trailing slashes — endpoint/publicBaseUrl are not normalized
  * at the schema (Council PR #105 note); every join happens here. */
 export function normalizeBaseUrl(url: string): string {
@@ -112,7 +124,7 @@ export class R2ObjectStore implements ObjectStore {
       if (!response.ok) throw new Error(`LIST ${prefix}: HTTP ${response.status}`);
       const xml = await response.text();
       for (const match of xml.matchAll(/<Key>([^<]+)<\/Key>/g)) {
-        keys.push(match[1]);
+        keys.push(decodeXmlEntities(match[1]));
       }
       const next = xml.match(/<NextContinuationToken>([^<]+)<\/NextContinuationToken>/);
       token = next?.[1];

--- a/packages/probe/src/r2-plane.ts
+++ b/packages/probe/src/r2-plane.ts
@@ -129,10 +129,15 @@ async function readAllReadings(
   // embed their run timestamp, so anything older than the rollup window
   // (e.g. compaction-orphaned strays) is skipped without a GET.
   const batchKeys = await store.list(`${V1}/readings/`);
-  const cutoffMs = nowMs - windowDays * DAY_MS;
+  // Batches only exist inside the compaction buffer (today + yesterday
+  // + the 1h fence, ticket #101); anything older is a compaction
+  // orphan whose day is already archived — skip without a GET. This is
+  // the ≤-one-day-of-runs bound from the header, NOT windowDays
+  // (Council r=2).
+  const batchCutoffMs = nowMs - 2 * DAY_MS;
   for (const key of batchKeys) {
     const stamp = key.match(/readings\/(\d{4}-\d{2}-\d{2})T/)?.[1];
-    if (stamp && Date.parse(`${stamp}T00:00:00Z`) < cutoffMs - DAY_MS) continue;
+    if (stamp && Date.parse(`${stamp}T00:00:00Z`) < batchCutoffMs) continue;
     const object = await store.get(key);
     if (!object) continue;
     try {
@@ -286,13 +291,28 @@ export async function reRenderFromRawR2(
     }
   }
 
+  const parseInputsOrAbort = <T>(
+    object: {body: string} | null,
+    schema: z.ZodType<T[]>,
+    key: string
+  ): T[] => {
+    if (!object) return [];
+    try {
+      return schema.parse(JSON.parse(object.body));
+    } catch (error) {
+      // ABORT, do not fall back (Council r=2): the runbook REWRITES the
+      // inputs — proceeding with [] would silently wipe real incidents.
+      throw new Error(
+        `refusing to re-render: ${key} is malformed (fix or delete it first): ${String(error).slice(0, 200)}`
+      );
+    }
+  };
+
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     const incidentsObj = await store.get(`${V1}/inputs/incidents.json`);
     const maintenanceObj = await store.get(`${V1}/inputs/maintenance.json`);
-    const incidents = incidentsObj ? incidentsFileSchema.parse(JSON.parse(incidentsObj.body)) : [];
-    const maintenance = maintenanceObj
-      ? maintenanceFileSchema.parse(JSON.parse(maintenanceObj.body))
-      : [];
+    const incidents = parseInputsOrAbort(incidentsObj, incidentsFileSchema, `${V1}/inputs/incidents.json`);
+    const maintenance = parseInputsOrAbort(maintenanceObj, maintenanceFileSchema, `${V1}/inputs/maintenance.json`);
 
     let incidentCount = 0;
     const nextIncidents = incidents.map(incident => {
@@ -313,18 +333,24 @@ export async function reRenderFromRawR2(
 
     try {
       // Conditional on the versions we read — a concurrent incident
-      // sync must not be clobbered by the runbook (Council r=1); lose
-      // the race, re-read, re-render.
-      await store.put(`${V1}/inputs/incidents.json`, JSON.stringify(nextIncidents), {
-        ...(incidentsObj ? {ifMatch: incidentsObj.etag} : {ifNoneMatch: '*' as const}),
-      });
+      // sync must not be clobbered (Council r=1). Two objects cannot
+      // commit atomically (Council r=2): maintenance is written FIRST
+      // and incidents LAST, and the whole runbook is idempotent — if
+      // retries exhaust between the two writes, simply re-running
+      // converges (each attempt re-reads both and re-renders from the
+      // immutable raw/ set).
       await store.put(`${V1}/inputs/maintenance.json`, JSON.stringify(nextMaintenance), {
         ...(maintenanceObj ? {ifMatch: maintenanceObj.etag} : {ifNoneMatch: '*' as const}),
+      });
+      await store.put(`${V1}/inputs/incidents.json`, JSON.stringify(nextIncidents), {
+        ...(incidentsObj ? {ifMatch: incidentsObj.etag} : {ifNoneMatch: '*' as const}),
       });
       return {incidents: incidentCount, maintenance: maintenanceCount};
     } catch (error) {
       if (!(error instanceof PreconditionFailedError)) throw error;
     }
   }
-  throw new Error(`re-render commit failed after ${maxRetries} attempts (write contention)`);
+  throw new Error(
+    `re-render commit failed after ${maxRetries} attempts (write contention) — the runbook is idempotent, re-run to converge`
+  );
 }

--- a/packages/probe/src/r2-plane.ts
+++ b/packages/probe/src/r2-plane.ts
@@ -167,8 +167,8 @@ export async function regenerateDerivedR2(
     throw new Error(`regenerateDerivedR2: generatedAt is not parseable: '${generatedAt}'`);
   }
 
-  let entityWritesSkipped = 0;
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    let entityWritesSkipped = 0;
     // ── read the full input set (fresh each attempt, §5 purity) ──
     const summaryBefore = await store.get(`${V1}/summary.json`);
     const allReadings = await readAllReadings(store, windowDays, generatedAtMs, onWarn);

--- a/packages/probe/src/r2-plane.ts
+++ b/packages/probe/src/r2-plane.ts
@@ -125,16 +125,26 @@ async function readAllReadings(
     }
   }
   // Batches not yet compacted (today, plus yesterday inside the
-  // compaction buffer) — list is bounded by the compaction cadence.
+  // compaction buffer). The read set is BOUNDED explicitly: batch keys
+  // embed their run timestamp, so anything older than the rollup window
+  // (e.g. compaction-orphaned strays) is skipped without a GET.
   const batchKeys = await store.list(`${V1}/readings/`);
+  const cutoffMs = nowMs - windowDays * DAY_MS;
   for (const key of batchKeys) {
+    const stamp = key.match(/readings\/(\d{4}-\d{2}-\d{2})T/)?.[1];
+    if (stamp && Date.parse(`${stamp}T00:00:00Z`) < cutoffMs - DAY_MS) continue;
     const object = await store.get(key);
     if (!object) continue;
-    const parsed = readingsArraySchema.safeParse(JSON.parse(object.body));
-    if (parsed.success) {
-      parsed.data.forEach(add);
-    } else {
-      onWarn(`malformed batch ${key} skipped`);
+    try {
+      const parsed = readingsArraySchema.safeParse(JSON.parse(object.body));
+      if (parsed.success) {
+        parsed.data.forEach(add);
+      } else {
+        onWarn(`malformed batch ${key} skipped`);
+      }
+    } catch (error) {
+      // A corrupt object must not crash the regenerator (Council r=1).
+      onWarn(`unparseable batch ${key} skipped: ${String(error)}`);
     }
   }
   return [...byKey.values()];
@@ -260,42 +270,61 @@ export async function regenerateDerivedR2(
  */
 export async function reRenderFromRawR2(
   store: ObjectStore,
-  now: Date
+  now: Date,
+  maxRetries = 3
 ): Promise<{incidents: number; maintenance: number}> {
   const rawKeys = await store.list(`${V1}/raw/`);
   const raws = new Map<number, string>();
   for (const key of rawKeys) {
     const object = await store.get(key);
     if (!object) continue;
-    const parsed = rawIncidentBodySchema.safeParse(JSON.parse(object.body));
-    if (parsed.success) raws.set(parsed.data.issueNumber, parsed.data.bodyMarkdown);
+    try {
+      const parsed = rawIncidentBodySchema.safeParse(JSON.parse(object.body));
+      if (parsed.success) raws.set(parsed.data.issueNumber, parsed.data.bodyMarkdown);
+    } catch {
+      // A corrupt raw object must not abort the runbook (Council r=1).
+    }
   }
 
-  const incidentsObj = await store.get(`${V1}/inputs/incidents.json`);
-  const maintenanceObj = await store.get(`${V1}/inputs/maintenance.json`);
-  const incidents = incidentsObj ? incidentsFileSchema.parse(JSON.parse(incidentsObj.body)) : [];
-  const maintenance = maintenanceObj
-    ? maintenanceFileSchema.parse(JSON.parse(maintenanceObj.body))
-    : [];
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const incidentsObj = await store.get(`${V1}/inputs/incidents.json`);
+    const maintenanceObj = await store.get(`${V1}/inputs/maintenance.json`);
+    const incidents = incidentsObj ? incidentsFileSchema.parse(JSON.parse(incidentsObj.body)) : [];
+    const maintenance = maintenanceObj
+      ? maintenanceFileSchema.parse(JSON.parse(maintenanceObj.body))
+      : [];
 
-  let incidentCount = 0;
-  const nextIncidents = incidents.map(incident => {
-    const raw = raws.get(incident.issueNumber);
-    if (raw === undefined) return incident;
-    incidentCount++;
-    return {...incident, bodyHtml: renderMarkdownToSafeHtml(raw)};
-  });
+    let incidentCount = 0;
+    const nextIncidents = incidents.map(incident => {
+      const raw = raws.get(incident.issueNumber);
+      if (raw === undefined) return incident;
+      incidentCount++;
+      return {...incident, bodyHtml: renderMarkdownToSafeHtml(raw)};
+    });
 
-  let maintenanceCount = 0;
-  const nextMaintenance = maintenance.map(window => {
-    const raw = raws.get(window.issueNumber);
-    if (raw === undefined) return window;
-    maintenanceCount++;
-    const {content} = extractFrontmatter(raw, now);
-    return {...window, bodyHtml: renderMarkdownToSafeHtml(content)};
-  });
+    let maintenanceCount = 0;
+    const nextMaintenance = maintenance.map(window => {
+      const raw = raws.get(window.issueNumber);
+      if (raw === undefined) return window;
+      maintenanceCount++;
+      const {content} = extractFrontmatter(raw, now);
+      return {...window, bodyHtml: renderMarkdownToSafeHtml(content)};
+    });
 
-  await store.put(`${V1}/inputs/incidents.json`, JSON.stringify(nextIncidents));
-  await store.put(`${V1}/inputs/maintenance.json`, JSON.stringify(nextMaintenance));
-  return {incidents: incidentCount, maintenance: maintenanceCount};
+    try {
+      // Conditional on the versions we read — a concurrent incident
+      // sync must not be clobbered by the runbook (Council r=1); lose
+      // the race, re-read, re-render.
+      await store.put(`${V1}/inputs/incidents.json`, JSON.stringify(nextIncidents), {
+        ...(incidentsObj ? {ifMatch: incidentsObj.etag} : {ifNoneMatch: '*' as const}),
+      });
+      await store.put(`${V1}/inputs/maintenance.json`, JSON.stringify(nextMaintenance), {
+        ...(maintenanceObj ? {ifMatch: maintenanceObj.etag} : {ifNoneMatch: '*' as const}),
+      });
+      return {incidents: incidentCount, maintenance: maintenanceCount};
+    } catch (error) {
+      if (!(error instanceof PreconditionFailedError)) throw error;
+    }
+  }
+  throw new Error(`re-render commit failed after ${maxRetries} attempts (write contention)`);
 }

--- a/packages/probe/src/r2-plane.ts
+++ b/packages/probe/src/r2-plane.ts
@@ -38,7 +38,7 @@ import {entitySlug} from './files';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const CURRENT_WINDOW_DAYS = 14;
-const V1 = 'status/v1';
+export const V1 = 'status/v1';
 
 const readingsArraySchema = z.array(compactReadingSchema);
 const incidentsFileSchema = z.array(incidentSchema);
@@ -101,7 +101,15 @@ async function readAllReadings(
   nowMs: number,
   onWarn: (message: string) => void
 ): Promise<CompactReading[]> {
-  const readings: CompactReading[] = [];
+  // Deduped by (svc, t): during the compaction window a reading exists
+  // in BOTH the day archive and its not-yet-deleted batch — without
+  // dedupe the rollups would double-count that window (Copilot PR #106
+  // r=1). Same identity rule as the migration merge.
+  const byKey = new Map<string, CompactReading>();
+  const add = (r: CompactReading) => {
+    const k = `${r.svc}|${r.t}`;
+    if (!byKey.has(k)) byKey.set(k, r);
+  };
   for (let d = 0; d < windowDays; d++) {
     const date = utcDateOf(nowMs - d * DAY_MS);
     const object = await store.get(archiveKey(date));
@@ -110,7 +118,7 @@ async function readAllReadings(
       if (!line.trim()) continue;
       try {
         const parsed = compactReadingSchema.safeParse(JSON.parse(line));
-        if (parsed.success) readings.push(parsed.data);
+        if (parsed.success) add(parsed.data);
       } catch {
         // One corrupt line must not lose the day (same rule as git plane).
       }
@@ -124,12 +132,12 @@ async function readAllReadings(
     if (!object) continue;
     const parsed = readingsArraySchema.safeParse(JSON.parse(object.body));
     if (parsed.success) {
-      readings.push(...parsed.data);
+      parsed.data.forEach(add);
     } else {
       onWarn(`malformed batch ${key} skipped`);
     }
   }
-  return readings;
+  return [...byKey.values()];
 }
 
 const textHash = (s: string): string => {
@@ -168,6 +176,8 @@ export async function regenerateDerivedR2(
   }
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    // Reset per attempt (Copilot PR #106 r=1): the returned count must
+    // describe the attempt that actually committed, not the sum.
     let entityWritesSkipped = 0;
     // ── read the full input set (fresh each attempt, §5 purity) ──
     const summaryBefore = await store.get(`${V1}/summary.json`);

--- a/packages/probe/src/r2-plane.ts
+++ b/packages/probe/src/r2-plane.ts
@@ -1,0 +1,291 @@
+/**
+ * R2 data-plane write pipeline (ADR-006 §1/§3; epic #97 ticket #99).
+ *
+ * The §5 purity rule carries over — summary.json is a pure function of
+ * the stored inputs — but git's multi-object atomicity does NOT.
+ * Council condition 1 (write-order consistency model): derived objects
+ * are written in dependency order with **summary.json LAST as the
+ * commit point**; clients read the summary first and treat entity
+ * details as enhancement-only, so the worst observable skew is a
+ * drill-down chart one cycle staler than the summary.
+ *
+ * Storage layout differences vs the git plane (ADR-006 §1):
+ * - readings land as ONE immutable batch object per run under
+ *   status/v1/readings/ (R2 cannot append); the daily compaction cron
+ *   (ticket #101) folds them into the standard archives/ JSONL
+ * - rollups read day archives (bounded) plus the CURRENT day's batches
+ *   (≤ one day of runs) — never the full batch history
+ */
+
+import {
+  buildDailyRollups,
+  buildSummary,
+  extractFrontmatter,
+  incidentsToAtom,
+  renderMarkdownToSafeHtml,
+} from '@stentorosaur/core/server';
+import {
+  compactReadingSchema,
+  incidentSchema,
+  maintenanceWindowSchema,
+  rawIncidentBodySchema,
+} from '@stentorosaur/core';
+import {z} from 'zod';
+import type {CompactReading, EntityRef} from '@stentorosaur/core';
+import type {ObjectStore} from './object-store';
+import {PreconditionFailedError} from './object-store';
+import {entitySlug} from './files';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CURRENT_WINDOW_DAYS = 14;
+const V1 = 'status/v1';
+
+const readingsArraySchema = z.array(compactReadingSchema);
+const incidentsFileSchema = z.array(incidentSchema);
+const maintenanceFileSchema = z.array(maintenanceWindowSchema);
+
+export interface R2RegenerateOptions {
+  generatedAt: string;
+  generatedBy: string;
+  entities: EntityRef[];
+  siteTitle: string;
+  siteUrl: string;
+  windowDays?: number;
+  /** §3 retry attempts for the summary commit point */
+  maxRetries?: number;
+  onWarn?: (message: string) => void;
+}
+
+function utcDateOf(ms: number): string {
+  return new Date(ms).toISOString().split('T')[0];
+}
+
+function archiveKey(date: string): string {
+  const [y, m] = date.split('-');
+  return `${V1}/archives/${y}/${m}/history-${date}.jsonl`;
+}
+
+/** One immutable batch object per run — the probe's only reading write. */
+export async function writeReadingsBatch(
+  store: ObjectStore,
+  readings: CompactReading[],
+  generatedAt: string,
+  runId: string
+): Promise<string> {
+  const key = `${V1}/readings/${generatedAt.replace(/[:.]/g, '-')}-${runId}.json`;
+  await store.put(key, JSON.stringify(readings), {ifNoneMatch: '*'});
+  return key;
+}
+
+async function readJsonOr<T>(
+  store: ObjectStore,
+  key: string,
+  schema: z.ZodType<T>,
+  fallback: T,
+  onWarn: (message: string) => void
+): Promise<T> {
+  const object = await store.get(key);
+  if (!object) return fallback;
+  try {
+    return schema.parse(JSON.parse(object.body));
+  } catch (error) {
+    onWarn(`malformed ${key}, using fallback: ${String(error)}`);
+    return fallback;
+  }
+}
+
+/** Archive window + current-day batches — the bounded §1 read set. */
+async function readAllReadings(
+  store: ObjectStore,
+  windowDays: number,
+  nowMs: number,
+  onWarn: (message: string) => void
+): Promise<CompactReading[]> {
+  const readings: CompactReading[] = [];
+  for (let d = 0; d < windowDays; d++) {
+    const date = utcDateOf(nowMs - d * DAY_MS);
+    const object = await store.get(archiveKey(date));
+    if (!object) continue;
+    for (const line of object.body.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const parsed = compactReadingSchema.safeParse(JSON.parse(line));
+        if (parsed.success) readings.push(parsed.data);
+      } catch {
+        // One corrupt line must not lose the day (same rule as git plane).
+      }
+    }
+  }
+  // Batches not yet compacted (today, plus yesterday inside the
+  // compaction buffer) — list is bounded by the compaction cadence.
+  const batchKeys = await store.list(`${V1}/readings/`);
+  for (const key of batchKeys) {
+    const object = await store.get(key);
+    if (!object) continue;
+    const parsed = readingsArraySchema.safeParse(JSON.parse(object.body));
+    if (parsed.success) {
+      readings.push(...parsed.data);
+    } else {
+      onWarn(`malformed batch ${key} skipped`);
+    }
+  }
+  return readings;
+}
+
+const textHash = (s: string): string => {
+  // FNV-1a — cheap content identity for the write-skip guard; not
+  // cryptographic and does not need to be.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16);
+};
+
+/**
+ * Rebuild every derived object from stored inputs, writing in the §3
+ * order: entity details → atom → SUMMARY LAST (commit point, If-Match
+ * guarded with regenerate-and-retry).
+ */
+export async function regenerateDerivedR2(
+  store: ObjectStore,
+  options: R2RegenerateOptions
+): Promise<{attempts: number; entityWritesSkipped: number}> {
+  const {
+    generatedAt,
+    generatedBy,
+    entities,
+    siteTitle,
+    siteUrl,
+    windowDays = 90,
+    maxRetries = 3,
+    onWarn = () => {},
+  } = options;
+  const generatedAtMs = Date.parse(generatedAt);
+  if (Number.isNaN(generatedAtMs)) {
+    throw new Error(`regenerateDerivedR2: generatedAt is not parseable: '${generatedAt}'`);
+  }
+
+  let entityWritesSkipped = 0;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    // ── read the full input set (fresh each attempt, §5 purity) ──
+    const summaryBefore = await store.get(`${V1}/summary.json`);
+    const allReadings = await readAllReadings(store, windowDays, generatedAtMs, onWarn);
+    const incidents = await readJsonOr(store, `${V1}/inputs/incidents.json`, incidentsFileSchema, [], onWarn);
+    const maintenance = await readJsonOr(store, `${V1}/inputs/maintenance.json`, maintenanceFileSchema, [], onWarn);
+
+    const windowStart = generatedAtMs - CURRENT_WINDOW_DAYS * DAY_MS;
+    const recent = allReadings.filter(r => r.t >= windowStart);
+
+    const summary = buildSummary({
+      generatedAt,
+      generatedBy,
+      entities,
+      readings: recent,
+      dailyRollups: buildDailyRollups(allReadings),
+      incidents,
+      maintenance,
+    });
+
+    // ── §3 write order: details → atom → summary LAST ──
+    for (const entity of entities) {
+      const key = `${V1}/entities/${entitySlug(entity.name)}.json`;
+      const detailReadings = recent
+        .filter(r => r.svc === entity.name)
+        .sort((a, b) => a.t - b.t);
+      // Content-hash guard (council condition 4): identical readings →
+      // skip the class-A write. generatedAt is excluded from the hash
+      // (it changes every run by definition).
+      const payload = JSON.stringify({
+        schemaVersion: 1,
+        generatedAt,
+        name: entity.name,
+        readings: detailReadings,
+      });
+      const existing = await store.get(key);
+      if (existing) {
+        try {
+          const current = JSON.parse(existing.body) as {readings?: unknown};
+          if (textHash(JSON.stringify(current.readings ?? null)) === textHash(JSON.stringify(detailReadings))) {
+            entityWritesSkipped++;
+            continue;
+          }
+        } catch {
+          // Unreadable existing object: overwrite with valid data.
+        }
+      }
+      await store.put(key, payload);
+    }
+
+    await store.put(
+      `${V1}/incidents.atom`,
+      incidentsToAtom([...summary.incidents.open, ...summary.incidents.recent], {
+        siteTitle,
+        siteUrl,
+        updated: generatedAt,
+      }),
+      {contentType: 'application/atom+xml'}
+    );
+
+    try {
+      await store.put(`${V1}/summary.json`, JSON.stringify(summary), {
+        ...(summaryBefore ? {ifMatch: summaryBefore.etag} : {ifNoneMatch: '*' as const}),
+      });
+      return {attempts: attempt, entityWritesSkipped};
+    } catch (error) {
+      if (!(error instanceof PreconditionFailedError)) throw error;
+      // Lost the race: another writer committed. Re-read ALL inputs and
+      // regenerate — deterministic over the merged state (§5).
+      onWarn(`summary commit lost the race (attempt ${attempt}), regenerating`);
+    }
+  }
+  throw new Error(`summary commit failed after ${maxRetries} attempts (persistent write contention)`);
+}
+
+/**
+ * §7 runbook on the r2 plane: re-render every derived bodyHtml from the
+ * raw/ markdown with the CURRENT sanitizer, rewriting the inputs.
+ * Mirrors regenerate-from-raw.ts (git plane).
+ */
+export async function reRenderFromRawR2(
+  store: ObjectStore,
+  now: Date
+): Promise<{incidents: number; maintenance: number}> {
+  const rawKeys = await store.list(`${V1}/raw/`);
+  const raws = new Map<number, string>();
+  for (const key of rawKeys) {
+    const object = await store.get(key);
+    if (!object) continue;
+    const parsed = rawIncidentBodySchema.safeParse(JSON.parse(object.body));
+    if (parsed.success) raws.set(parsed.data.issueNumber, parsed.data.bodyMarkdown);
+  }
+
+  const incidentsObj = await store.get(`${V1}/inputs/incidents.json`);
+  const maintenanceObj = await store.get(`${V1}/inputs/maintenance.json`);
+  const incidents = incidentsObj ? incidentsFileSchema.parse(JSON.parse(incidentsObj.body)) : [];
+  const maintenance = maintenanceObj
+    ? maintenanceFileSchema.parse(JSON.parse(maintenanceObj.body))
+    : [];
+
+  let incidentCount = 0;
+  const nextIncidents = incidents.map(incident => {
+    const raw = raws.get(incident.issueNumber);
+    if (raw === undefined) return incident;
+    incidentCount++;
+    return {...incident, bodyHtml: renderMarkdownToSafeHtml(raw)};
+  });
+
+  let maintenanceCount = 0;
+  const nextMaintenance = maintenance.map(window => {
+    const raw = raws.get(window.issueNumber);
+    if (raw === undefined) return window;
+    maintenanceCount++;
+    const {content} = extractFrontmatter(raw, now);
+    return {...window, bodyHtml: renderMarkdownToSafeHtml(content)};
+  });
+
+  await store.put(`${V1}/inputs/incidents.json`, JSON.stringify(nextIncidents));
+  await store.put(`${V1}/inputs/maintenance.json`, JSON.stringify(nextMaintenance));
+  return {incidents: incidentCount, maintenance: maintenanceCount};
+}

--- a/packages/probe/src/update-incidents.ts
+++ b/packages/probe/src/update-incidents.ts
@@ -6,7 +6,13 @@
 
 import {LabelParser, isMaintenanceIssue, issueToIncidentV1} from '@stentorosaur/core';
 import {issueToMaintenanceV1, renderMarkdownToSafeHtml} from '@stentorosaur/core/server';
-import type {EntityRef, LabelScheme} from '@stentorosaur/core';
+import type {
+  EntityRef,
+  LabelScheme,
+  MaintenanceWindowV1,
+  RawIncidentBody,
+  StatusIncidentV1,
+} from '@stentorosaur/core';
 import type {IssuePayload} from '@stentorosaur/core';
 import {writeIncidentInputs, writeRawIssueBody} from './inputs';
 
@@ -80,21 +86,27 @@ export interface UpdateIncidentInputsOptions {
  * core transforms plus file writes — callable from tests with fixture
  * issue payloads (no network).
  */
-export function writeIssueInputs(
-  rootDir: string,
+/** Pure transform half — shared by the git and r2 writers (#99). */
+export function transformIssueInputs(
   issues: IssuePayload[],
   options: UpdateIncidentInputsOptions
-): {incidents: number; maintenance: number; skipped: number} {
+): {
+  incidents: StatusIncidentV1[];
+  maintenance: MaintenanceWindowV1[];
+  raws: RawIncidentBody[];
+  skipped: number;
+} {
   const {entities, maintenanceLabels, labelScheme, now} = options;
   const labelParser = new LabelParser(labelScheme);
   const ctx = {entities, labelParser, renderHtml: renderMarkdownToSafeHtml};
 
-  const incidents = [];
-  const maintenance = [];
+  const incidents: StatusIncidentV1[] = [];
+  const maintenance: MaintenanceWindowV1[] = [];
+  const raws: RawIncidentBody[] = [];
   let skipped = 0;
 
   for (const issue of issues) {
-    writeRawIssueBody(rootDir, {
+    raws.push({
       schemaVersion: 1,
       issueNumber: issue.number,
       updatedAt: issue.updated_at,
@@ -113,7 +125,18 @@ export function writeIssueInputs(
       incidents.push(issueToIncidentV1(issue, ctx));
     }
   }
+  return {incidents, maintenance, raws, skipped};
+}
 
+export function writeIssueInputs(
+  rootDir: string,
+  issues: IssuePayload[],
+  options: UpdateIncidentInputsOptions
+): {incidents: number; maintenance: number; skipped: number} {
+  const {incidents, maintenance, raws, skipped} = transformIssueInputs(issues, options);
+  for (const raw of raws) {
+    writeRawIssueBody(rootDir, raw);
+  }
   writeIncidentInputs(rootDir, incidents, maintenance);
   return {incidents: incidents.length, maintenance: maintenance.length, skipped};
 }

--- a/packages/probe/src/update-incidents.ts
+++ b/packages/probe/src/update-incidents.ts
@@ -81,11 +81,6 @@ export interface UpdateIncidentInputsOptions {
   now: Date;
 }
 
-/**
- * Transform fetched issues into on-branch inputs. Pure orchestration of
- * core transforms plus file writes — callable from tests with fixture
- * issue payloads (no network).
- */
 /** Pure transform half — shared by the git and r2 writers (#99). */
 export function transformIssueInputs(
   issues: IssuePayload[],


### PR DESCRIPTION
Closes #99 (epic #97, ADR-006 §1/§3)

The second child: the CLI writers gain an R2 backend behind the SAME commands, selected by `dataPlane.kind`.

## Council conditions as tests

- **Condition 1 (write-order consistency)**: derived objects written in dependency order, `summary.json` strictly LAST as the commit point — asserted via the MemoryObjectStore operation log; If-Match retry re-reads ALL inputs and regenerates (converges under injected contention, loud failure after maxRetries)
- **Condition 4 (budget)**: content-hash guard skips unchanged entity-detail writes (op-count assertions); base URLs slash-normalized per the #105 council note

## Design

- `ObjectStore` interface; `R2ObjectStore` via **aws4fetch** (SigV4-over-fetch, Workers-compatible — the same client #100 will use; no AWS SDK)
- One immutable readings batch per run (`ifNoneMatch: '*'`); rollups read day archives + uncompacted batches (bounded set, class-B math per ADR)
- Issue transform extracted pure (`transformIssueInputs`) and shared by git/r2 writers; §7 re-render implemented for r2
- The r2 plane never touches the local filesystem (asserted)

Probe 116 green (12 new), core 73, build + typecheck green.