### PR TITLE
feat: Worker R2-writer mode + serving route (#100)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,12 +47,19 @@
     "./server": {
       "types": "./lib/server.d.ts",
       "default": "./lib/server.js"
+    },
+    "./summary": {
+      "types": "./lib/summary.d.ts",
+      "default": "./lib/summary.js"
     }
   },
   "typesVersions": {
     "*": {
       "server": [
         "lib/server.d.ts"
+      ],
+      "summary": [
+        "lib/summary.d.ts"
       ]
     }
   }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -7,6 +7,6 @@
  */
 
 export * from './render';
-export * from './maintenance';
-export * from './build-summary';
-export * from './atom';
+// The Workers-safe half lives in './summary' (ticket #100); re-exported
+// here so existing server-side imports keep working unchanged.
+export * from './summary';

--- a/packages/core/src/summary.ts
+++ b/packages/core/src/summary.ts
@@ -1,0 +1,14 @@
+/**
+ * '@stentorosaur/core/summary' — the WORKERS-SAFE write-side entry
+ * (ADR-006 ticket #100).
+ *
+ * Everything here runs in the Cloudflare Workers runtime: aggregation,
+ * the atom feed, and maintenance-frontmatter parsing (chrono-node is
+ * pure JS). The full './server' barrel additionally re-exports the
+ * jsdom sanitizer, which does NOT run in Workers — Worker bundles must
+ * import from HERE, never from './server'.
+ */
+
+export * from './maintenance';
+export * from './build-summary';
+export * from './atom';

--- a/packages/docusaurus-plugin-stentorosaur/templates/worker/wrangler-r2.toml
+++ b/packages/docusaurus-plugin-stentorosaur/templates/worker/wrangler-r2.toml
@@ -1,0 +1,46 @@
+# Cloudflare Worker probe — Profile C: direct R2 writes + serving route
+# (ADR-006 §2; see ../workflows/README.md for the full profile chooser).
+#
+# The Worker holds ONLY a bucket binding — no GitHub credentials, no
+# repository_dispatch, zero GitHub Actions in the monitoring loop.
+#
+# Setup:
+#   1. Create the bucket:   wrangler r2 bucket create status
+#   2. Copy worker.mjs + this file; npm i @stentorosaur/probe
+#   3. wrangler deploy
+#   4. Point the plugin's dataUrl at
+#      https://<your-custom-domain>/status/v1/summary.json
+
+name = "stentorosaur-probe-r2"
+main = "worker.mjs"
+compatibility_date = "2025-01-01"
+
+[triggers]
+# Zero Actions billing in this profile — 1-minute resolution is a
+# config change. Watch the R2 class-A budget formula in the README:
+# writes/month ≈ runs_per_day × (N_entities + 3) × 30.
+crons = ["*/5 * * * *"]
+
+[[r2_buckets]]
+binding = "STATUS_BUCKET"
+bucket_name = "status"
+
+# ── REQUIRED: serve through a Cloudflare CUSTOM DOMAIN ──────────────
+# On workers.dev every client poll invokes the Worker and the free plan
+# caps Workers at ~100k requests/day (ADR-006 council condition 4).
+# Behind a custom domain the CDN cache absorbs polls within max-age.
+# Do NOT ship a workers.dev dataUrl.
+[[routes]]
+pattern = "status.example.com/status/v1/*"
+custom_domain = true
+
+[vars]
+TARGETS = '[{"system":"api","url":"https://api.example.com/health","expectedCodes":[200]}]'
+# Optional display metadata for the summary (defaults derived from TARGETS):
+# ENTITIES = '[{"name":"api","type":"system","displayName":"API"}]'
+SITE_TITLE = "System Status"
+SITE_URL = "https://example.com"
+
+# NOTE: incident sync stays on GitHub Actions in ALL profiles (the
+# jsdom sanitizer does not run in Workers — ADR-006 §4). Install
+# status-update-v1.yml and run it with --data-plane r2.

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md
@@ -274,3 +274,24 @@ model for a long-lived write credential in Worker secrets — acceptable
 for some, but not the default (ADR-005 §6). If you choose it, reuse the
 same token scope as step 2 and write via `stentorosaur probe` in any
 git-capable runtime instead of the Worker.
+
+### Profile C: R2 object storage (ADR-006 — zero-Actions monitoring)
+
+For the full escape from per-job Actions billing, the Worker writes
+`status/v1` directly to an R2 bucket via a binding (no GitHub
+credentials at all) and a serving route publishes it with proper
+`Cache-Control`/`ETag`/CORS — see `../worker/wrangler-r2.toml`.
+
+- **Custom domain REQUIRED** for serving (council condition): on
+  workers.dev every client poll invokes the Worker against the ~100k
+  req/day free cap; behind a custom domain the CDN absorbs polls.
+- Budget formula: R2 class-A writes/month ≈
+  `runs_per_day × (N_entities + 3) × 30` — unchanged entity details
+  are skipped automatically (content-hash guard).
+- Set `dataPlane: {kind: 'r2', …}` in `stentorosaur.config.js`; the
+  CLI writers (incl. `status-update-v1.yml`'s incident sync) then
+  target the bucket via the S3 API using `R2_ACCESS_KEY_ID` /
+  `R2_SECRET_ACCESS_KEY` secrets.
+- Incident sync stays on Actions in all profiles (jsdom sanitizer,
+  ADR-006 §4) — its per-event cost is a few minutes/month.
+- History compaction for the batch objects ships with ticket #101.

--- a/packages/probe/__tests__/r2-writer.test.ts
+++ b/packages/probe/__tests__/r2-writer.test.ts
@@ -13,7 +13,8 @@
 import {parseSummary} from '@stentorosaur/core';
 import type {CompactReading} from '@stentorosaur/core';
 import {MemoryObjectStore, PreconditionFailedError, normalizeBaseUrl} from '../src/object-store';
-import {regenerateDerivedR2, reRenderFromRawR2, writeReadingsBatch} from '../src/r2-plane';
+import {regenerateDerivedR2, writeReadingsBatch} from '../src/r2-plane';
+import {reRenderFromRawR2} from '../src/r2-raw-rerender';
 
 const NOW = Date.parse('2026-07-15T12:00:00.000Z');
 const GENERATED_AT = new Date(NOW).toISOString();

--- a/packages/probe/__tests__/worker-r2.test.ts
+++ b/packages/probe/__tests__/worker-r2.test.ts
@@ -44,7 +44,7 @@ class FakeR2Bucket implements R2BucketLike {
     }
     const etag = `"b${++this.etagCounter}"`;
     this.objects.set(key, {body: value, etag});
-    return {};
+    return {httpEtag: etag, text: async () => value};
   }
 
   async list({prefix, cursor}: {prefix: string; cursor?: string}) {
@@ -145,6 +145,10 @@ describe('runWorkerProbeR2 (Profile C probe cycle)', () => {
 
     await expect(
       runWorkerProbeR2({...r2Env(bucket), ENTITIES: '[{"nope": true}]'}, {fetchImpl, now: NOW})
+    ).rejects.toThrow(/ENTITIES/);
+
+    await expect(
+      runWorkerProbeR2({...r2Env(bucket), ENTITIES: 'not valid json'}, {fetchImpl, now: NOW})
     ).rejects.toThrow(/ENTITIES/);
   });
 });

--- a/packages/probe/__tests__/worker-r2.test.ts
+++ b/packages/probe/__tests__/worker-r2.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Worker Profile C tests (ADR-006 §2; epic #97 ticket #100): the R2
+ * binding adapter, the direct-write probe cycle, the serving route,
+ * and the jsdom-free bundle-graph guard.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {parseSummary} from '@stentorosaur/core';
+import {PreconditionFailedError} from '../src/object-store';
+import {
+  BindingObjectStore,
+  runWorkerProbeR2,
+  serveStatusV1,
+  type R2BucketLike,
+  type WorkerEnv,
+} from '../src/worker';
+
+const NOW = Date.parse('2026-07-15T12:00:00.000Z');
+
+/** In-memory R2Bucket with real conditional-put semantics (null on
+ * precondition failure, like the actual binding). */
+class FakeR2Bucket implements R2BucketLike {
+  readonly objects = new Map<string, {body: string; etag: string}>();
+  private etagCounter = 0;
+
+  async get(key: string) {
+    const entry = this.objects.get(key);
+    if (!entry) return null;
+    return {httpEtag: entry.etag, text: async () => entry.body};
+  }
+
+  async put(
+    key: string,
+    value: string,
+    options?: {onlyIf?: {etagMatches?: string; etagDoesNotMatch?: string}}
+  ) {
+    const existing = this.objects.get(key);
+    if (options?.onlyIf?.etagMatches && existing?.etag !== options.onlyIf.etagMatches) {
+      return null; // the binding signals precondition failure with null
+    }
+    if (options?.onlyIf?.etagDoesNotMatch === '*' && existing) {
+      return null;
+    }
+    const etag = `"b${++this.etagCounter}"`;
+    this.objects.set(key, {body: value, etag});
+    return {};
+  }
+
+  async list({prefix, cursor}: {prefix: string; cursor?: string}) {
+    // Two-key pages to exercise pagination.
+    const all = [...this.objects.keys()].filter(k => k.startsWith(prefix)).sort();
+    const start = cursor ? Number(cursor) : 0;
+    const page = all.slice(start, start + 2);
+    const nextStart = start + 2;
+    return {
+      objects: page.map(key => ({key})),
+      truncated: nextStart < all.length,
+      cursor: String(nextStart),
+    };
+  }
+
+  async delete(key: string) {
+    this.objects.delete(key);
+  }
+}
+
+const TARGETS = JSON.stringify([{system: 'api', url: 'https://api.test/health'}]);
+
+function r2Env(bucket: R2BucketLike): WorkerEnv {
+  return {
+    GITHUB_TOKEN: '',
+    GITHUB_OWNER: 'o',
+    GITHUB_REPO: 'r',
+    TARGETS,
+    STATUS_BUCKET: bucket,
+    SITE_TITLE: 'T',
+    SITE_URL: 'https://t.example.com',
+  };
+}
+
+describe('BindingObjectStore', () => {
+  it('maps the binding null-on-precondition to PreconditionFailedError', async () => {
+    const bucket = new FakeR2Bucket();
+    const store = new BindingObjectStore(bucket);
+    await store.put('k', 'v1');
+    await expect(store.put('k', 'v2', {ifMatch: '"wrong"'})).rejects.toThrow(
+      PreconditionFailedError
+    );
+    await expect(store.put('k', 'v2', {ifNoneMatch: '*'})).rejects.toThrow(
+      PreconditionFailedError
+    );
+  });
+
+  it('paginates list via cursors', async () => {
+    const bucket = new FakeR2Bucket();
+    const store = new BindingObjectStore(bucket);
+    for (let i = 0; i < 5; i++) await store.put(`p/${i}`, 'x');
+    expect(await store.list('p/')).toHaveLength(5);
+  });
+
+  it('round-trips body + etag through get', async () => {
+    const bucket = new FakeR2Bucket();
+    const store = new BindingObjectStore(bucket);
+    const {etag} = await store.put('k', 'body');
+    expect(await store.get('k')).toEqual({body: 'body', etag});
+  });
+});
+
+describe('runWorkerProbeR2 (Profile C probe cycle)', () => {
+  it('checks targets, writes the batch, and commits a schema-valid summary', async () => {
+    const bucket = new FakeR2Bucket();
+    const fetchImpl = (async () => ({
+      status: 200,
+      ok: true,
+      text: async () => 'ok',
+      headers: {get: () => null},
+    })) as unknown as typeof fetch;
+
+    const result = await runWorkerProbeR2(r2Env(bucket), {fetchImpl, now: NOW});
+    expect(result.readings[0]).toMatchObject({svc: 'api', state: 'up'});
+
+    const store = new BindingObjectStore(bucket);
+    const summary = parseSummary(JSON.parse((await store.get('status/v1/summary.json'))!.body));
+    expect(summary.generatedBy).toBe('stentorosaur-worker');
+    expect(summary.entities[0]).toMatchObject({name: 'api', status: 'up'});
+    expect([...bucket.objects.keys()].some(k => k.startsWith('status/v1/readings/'))).toBe(true);
+  });
+
+  it('honors ENTITIES display metadata and rejects malformed values', async () => {
+    const bucket = new FakeR2Bucket();
+    const fetchImpl = (async () => ({
+      status: 200,
+      ok: true,
+      text: async () => 'ok',
+      headers: {get: () => null},
+    })) as unknown as typeof fetch;
+
+    const env = {...r2Env(bucket), ENTITIES: JSON.stringify([{name: 'api', type: 'system', displayName: 'API'}])};
+    await runWorkerProbeR2(env, {fetchImpl, now: NOW});
+    const summary = parseSummary(
+      JSON.parse((await new BindingObjectStore(bucket).get('status/v1/summary.json'))!.body)
+    );
+    expect(summary.entities[0].displayName).toBe('API');
+
+    await expect(
+      runWorkerProbeR2({...r2Env(bucket), ENTITIES: '[{"nope": true}]'}, {fetchImpl, now: NOW})
+    ).rejects.toThrow(/ENTITIES/);
+  });
+});
+
+describe('serveStatusV1 (serving route)', () => {
+  async function served(bucket: FakeR2Bucket, url: string, init?: RequestInit) {
+    return serveStatusV1(new Request(url, init), r2Env(bucket));
+  }
+
+  it('serves status/v1 objects with cache, etag, and CORS headers', async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put('status/v1/summary.json', '{"x":1}');
+    const response = await served(bucket, 'https://status.example.com/status/v1/summary.json');
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"x":1}');
+    expect(response.headers.get('cache-control')).toBe('public, max-age=60');
+    expect(response.headers.get('etag')).toMatch(/^"b/);
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    expect(response.headers.get('content-type')).toBe('application/json');
+  });
+
+  it('returns 304 on matching If-None-Match (the §4 client protocol)', async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put('status/v1/summary.json', '{}');
+    const first = await served(bucket, 'https://s.test/status/v1/summary.json');
+    const etag = first.headers.get('etag')!;
+    const second = await served(bucket, 'https://s.test/status/v1/summary.json', {
+      headers: {'if-none-match': etag},
+    });
+    expect(second.status).toBe(304);
+  });
+
+  it('404s outside status/v1 and for missing objects; 405s non-GET', async () => {
+    const bucket = new FakeR2Bucket();
+    expect((await served(bucket, 'https://s.test/secrets.txt')).status).toBe(404);
+    expect((await served(bucket, 'https://s.test/status/v1/missing.json')).status).toBe(404);
+    expect(
+      (await served(bucket, 'https://s.test/status/v1/summary.json', {method: 'POST', body: 'x'}))
+        .status
+    ).toBe(405);
+    expect(
+      (await served(bucket, 'https://s.test/status/v1/summary.json', {method: 'OPTIONS'})).status
+    ).toBe(204);
+  });
+
+  it('serves the atom feed with its content type', async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put('status/v1/incidents.atom', '<feed/>');
+    const response = await served(bucket, 'https://s.test/status/v1/incidents.atom');
+    expect(response.headers.get('content-type')).toBe('application/atom+xml');
+  });
+});
+
+describe('Workers bundle-graph guard (no jsdom reachable from worker entry)', () => {
+  it('the compiled worker module graph never requires jsdom/render', () => {
+    const LIB = path.join(__dirname, '..', 'lib');
+    const CORE_LIB = path.join(__dirname, '..', '..', 'core', 'lib');
+    const seen = new Set<string>();
+    const queue = [path.join(LIB, 'worker.js')];
+    const offenders: string[] = [];
+
+    while (queue.length) {
+      const file = queue.pop()!;
+      if (seen.has(file) || !fs.existsSync(file)) continue;
+      seen.add(file);
+      const source = fs.readFileSync(file, 'utf8');
+      for (const match of source.matchAll(/require\("([^"]+)"\)/g)) {
+        const spec = match[1];
+        if (spec === 'jsdom' || spec === 'dompurify' || spec === 'marked') {
+          offenders.push(`${path.relative(LIB, file)} requires ${spec}`);
+        } else if (spec.startsWith('.')) {
+          queue.push(path.resolve(path.dirname(file), spec.endsWith('.js') ? spec : `${spec}.js`));
+        } else if (spec === '@stentorosaur/core/summary') {
+          queue.push(path.join(CORE_LIB, 'summary.js'));
+        } else if (spec === '@stentorosaur/core/server') {
+          offenders.push(`${path.relative(LIB, file)} imports the jsdom server barrel`);
+        } else if (spec === '@stentorosaur/core') {
+          queue.push(path.join(CORE_LIB, 'index.js'));
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+    expect(seen.size).toBeGreaterThan(3); // the walk actually traversed
+  });
+});

--- a/packages/probe/src/cli.ts
+++ b/packages/probe/src/cli.ts
@@ -29,7 +29,8 @@ import {migrateHistoricalData, planMigration} from './migrate';
 import type {MigrationReport} from './migrate';
 import {R2ObjectStore} from './object-store';
 import type {ObjectStore} from './object-store';
-import {V1, regenerateDerivedR2, reRenderFromRawR2, writeReadingsBatch} from './r2-plane';
+import {V1, regenerateDerivedR2, writeReadingsBatch} from './r2-plane';
+import {reRenderFromRawR2} from './r2-raw-rerender';
 import {parseProbeDispatch, parseSummary} from '@stentorosaur/core';
 import type {CompactReading, StentorosaurConfig} from '@stentorosaur/core';
 

--- a/packages/probe/src/index.ts
+++ b/packages/probe/src/index.ts
@@ -17,4 +17,5 @@ export * from './regenerate-from-raw';
 export * from './migrate';
 export * from './object-store';
 export * from './r2-plane';
+export * from './r2-raw-rerender';
 export * from './cli';

--- a/packages/probe/src/r2-plane.ts
+++ b/packages/probe/src/r2-plane.ts
@@ -17,13 +17,10 @@
  *   (≤ one day of runs) — never the full batch history
  */
 
-import {
-  buildDailyRollups,
-  buildSummary,
-  extractFrontmatter,
-  incidentsToAtom,
-  renderMarkdownToSafeHtml,
-} from '@stentorosaur/core/server';
+// Workers-safe imports ONLY (ticket #100): this module runs inside the
+// Cloudflare Worker. The jsdom-dependent §7 runbook lives in
+// r2-raw-rerender.ts, which imports the server barrel.
+import {buildDailyRollups, buildSummary, incidentsToAtom} from '@stentorosaur/core/summary';
 import {
   compactReadingSchema,
   incidentSchema,
@@ -266,91 +263,4 @@ export async function regenerateDerivedR2(
     }
   }
   throw new Error(`summary commit failed after ${maxRetries} attempts (persistent write contention)`);
-}
-
-/**
- * §7 runbook on the r2 plane: re-render every derived bodyHtml from the
- * raw/ markdown with the CURRENT sanitizer, rewriting the inputs.
- * Mirrors regenerate-from-raw.ts (git plane).
- */
-export async function reRenderFromRawR2(
-  store: ObjectStore,
-  now: Date,
-  maxRetries = 3
-): Promise<{incidents: number; maintenance: number}> {
-  const rawKeys = await store.list(`${V1}/raw/`);
-  const raws = new Map<number, string>();
-  for (const key of rawKeys) {
-    const object = await store.get(key);
-    if (!object) continue;
-    try {
-      const parsed = rawIncidentBodySchema.safeParse(JSON.parse(object.body));
-      if (parsed.success) raws.set(parsed.data.issueNumber, parsed.data.bodyMarkdown);
-    } catch {
-      // A corrupt raw object must not abort the runbook (Council r=1).
-    }
-  }
-
-  const parseInputsOrAbort = <T>(
-    object: {body: string} | null,
-    schema: z.ZodType<T[]>,
-    key: string
-  ): T[] => {
-    if (!object) return [];
-    try {
-      return schema.parse(JSON.parse(object.body));
-    } catch (error) {
-      // ABORT, do not fall back (Council r=2): the runbook REWRITES the
-      // inputs — proceeding with [] would silently wipe real incidents.
-      throw new Error(
-        `refusing to re-render: ${key} is malformed (fix or delete it first): ${String(error).slice(0, 200)}`
-      );
-    }
-  };
-
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    const incidentsObj = await store.get(`${V1}/inputs/incidents.json`);
-    const maintenanceObj = await store.get(`${V1}/inputs/maintenance.json`);
-    const incidents = parseInputsOrAbort(incidentsObj, incidentsFileSchema, `${V1}/inputs/incidents.json`);
-    const maintenance = parseInputsOrAbort(maintenanceObj, maintenanceFileSchema, `${V1}/inputs/maintenance.json`);
-
-    let incidentCount = 0;
-    const nextIncidents = incidents.map(incident => {
-      const raw = raws.get(incident.issueNumber);
-      if (raw === undefined) return incident;
-      incidentCount++;
-      return {...incident, bodyHtml: renderMarkdownToSafeHtml(raw)};
-    });
-
-    let maintenanceCount = 0;
-    const nextMaintenance = maintenance.map(window => {
-      const raw = raws.get(window.issueNumber);
-      if (raw === undefined) return window;
-      maintenanceCount++;
-      const {content} = extractFrontmatter(raw, now);
-      return {...window, bodyHtml: renderMarkdownToSafeHtml(content)};
-    });
-
-    try {
-      // Conditional on the versions we read — a concurrent incident
-      // sync must not be clobbered (Council r=1). Two objects cannot
-      // commit atomically (Council r=2): maintenance is written FIRST
-      // and incidents LAST, and the whole runbook is idempotent — if
-      // retries exhaust between the two writes, simply re-running
-      // converges (each attempt re-reads both and re-renders from the
-      // immutable raw/ set).
-      await store.put(`${V1}/inputs/maintenance.json`, JSON.stringify(nextMaintenance), {
-        ...(maintenanceObj ? {ifMatch: maintenanceObj.etag} : {ifNoneMatch: '*' as const}),
-      });
-      await store.put(`${V1}/inputs/incidents.json`, JSON.stringify(nextIncidents), {
-        ...(incidentsObj ? {ifMatch: incidentsObj.etag} : {ifNoneMatch: '*' as const}),
-      });
-      return {incidents: incidentCount, maintenance: maintenanceCount};
-    } catch (error) {
-      if (!(error instanceof PreconditionFailedError)) throw error;
-    }
-  }
-  throw new Error(
-    `re-render commit failed after ${maxRetries} attempts (write contention) — the runbook is idempotent, re-run to converge`
-  );
 }

--- a/packages/probe/src/r2-raw-rerender.ts
+++ b/packages/probe/src/r2-raw-rerender.ts
@@ -1,0 +1,102 @@
+/**
+ * §7 sanitizer runbook on the r2 plane — SERVER-ONLY (jsdom via the
+ * core server barrel). Kept out of r2-plane.ts so Worker bundles never
+ * pull jsdom (ADR-006 ticket #100).
+ */
+
+import {z} from 'zod';
+import {extractFrontmatter, renderMarkdownToSafeHtml} from '@stentorosaur/core/server';
+import {incidentSchema, maintenanceWindowSchema, rawIncidentBodySchema} from '@stentorosaur/core';
+import type {ObjectStore} from './object-store';
+import {PreconditionFailedError} from './object-store';
+import {V1} from './r2-plane';
+
+const incidentsFileSchema = z.array(incidentSchema);
+const maintenanceFileSchema = z.array(maintenanceWindowSchema);
+
+/**
+ * §7 runbook on the r2 plane: re-render every derived bodyHtml from the
+ * raw/ markdown with the CURRENT sanitizer, rewriting the inputs.
+ * Mirrors regenerate-from-raw.ts (git plane).
+ */
+export async function reRenderFromRawR2(
+  store: ObjectStore,
+  now: Date,
+  maxRetries = 3
+): Promise<{incidents: number; maintenance: number}> {
+  const rawKeys = await store.list(`${V1}/raw/`);
+  const raws = new Map<number, string>();
+  for (const key of rawKeys) {
+    const object = await store.get(key);
+    if (!object) continue;
+    try {
+      const parsed = rawIncidentBodySchema.safeParse(JSON.parse(object.body));
+      if (parsed.success) raws.set(parsed.data.issueNumber, parsed.data.bodyMarkdown);
+    } catch {
+      // A corrupt raw object must not abort the runbook (Council r=1).
+    }
+  }
+
+  const parseInputsOrAbort = <T>(
+    object: {body: string} | null,
+    schema: z.ZodType<T[]>,
+    key: string
+  ): T[] => {
+    if (!object) return [];
+    try {
+      return schema.parse(JSON.parse(object.body));
+    } catch (error) {
+      // ABORT, do not fall back (Council r=2): the runbook REWRITES the
+      // inputs — proceeding with [] would silently wipe real incidents.
+      throw new Error(
+        `refusing to re-render: ${key} is malformed (fix or delete it first): ${String(error).slice(0, 200)}`
+      );
+    }
+  };
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const incidentsObj = await store.get(`${V1}/inputs/incidents.json`);
+    const maintenanceObj = await store.get(`${V1}/inputs/maintenance.json`);
+    const incidents = parseInputsOrAbort(incidentsObj, incidentsFileSchema, `${V1}/inputs/incidents.json`);
+    const maintenance = parseInputsOrAbort(maintenanceObj, maintenanceFileSchema, `${V1}/inputs/maintenance.json`);
+
+    let incidentCount = 0;
+    const nextIncidents = incidents.map(incident => {
+      const raw = raws.get(incident.issueNumber);
+      if (raw === undefined) return incident;
+      incidentCount++;
+      return {...incident, bodyHtml: renderMarkdownToSafeHtml(raw)};
+    });
+
+    let maintenanceCount = 0;
+    const nextMaintenance = maintenance.map(window => {
+      const raw = raws.get(window.issueNumber);
+      if (raw === undefined) return window;
+      maintenanceCount++;
+      const {content} = extractFrontmatter(raw, now);
+      return {...window, bodyHtml: renderMarkdownToSafeHtml(content)};
+    });
+
+    try {
+      // Conditional on the versions we read — a concurrent incident
+      // sync must not be clobbered (Council r=1). Two objects cannot
+      // commit atomically (Council r=2): maintenance is written FIRST
+      // and incidents LAST, and the whole runbook is idempotent — if
+      // retries exhaust between the two writes, simply re-running
+      // converges (each attempt re-reads both and re-renders from the
+      // immutable raw/ set).
+      await store.put(`${V1}/inputs/maintenance.json`, JSON.stringify(nextMaintenance), {
+        ...(maintenanceObj ? {ifMatch: maintenanceObj.etag} : {ifNoneMatch: '*' as const}),
+      });
+      await store.put(`${V1}/inputs/incidents.json`, JSON.stringify(nextIncidents), {
+        ...(incidentsObj ? {ifMatch: incidentsObj.etag} : {ifNoneMatch: '*' as const}),
+      });
+      return {incidents: incidentCount, maintenance: maintenanceCount};
+    } catch (error) {
+      if (!(error instanceof PreconditionFailedError)) throw error;
+    }
+  }
+  throw new Error(
+    `re-render commit failed after ${maxRetries} attempts (write contention) — the runbook is idempotent, re-run to converge`
+  );
+}

--- a/packages/probe/src/worker.ts
+++ b/packages/probe/src/worker.ts
@@ -17,12 +17,16 @@
 import {runChecks} from './check';
 import type {CheckTarget} from './check';
 import {parseProbeDispatch} from '@stentorosaur/core';
-import type {CompactReading, ProbeDispatchPayload} from '@stentorosaur/core';
+import type {CompactReading, EntityRef, ProbeDispatchPayload} from '@stentorosaur/core';
+import type {ObjectStore, PutOptions, StoredObject} from './object-store';
+import {PreconditionFailedError} from './object-store';
+import {V1, regenerateDerivedR2, writeReadingsBatch} from './r2-plane';
 
 export const DISPATCH_EVENT_TYPE = 'stentorosaur-probe';
 
 export interface WorkerEnv {
-  /** Fine-grained PAT able to send repository_dispatch to the repo */
+  /** Fine-grained PAT able to send repository_dispatch to the repo
+   * (dispatch mode only — unused when STATUS_BUCKET is bound) */
   GITHUB_TOKEN: string;
   GITHUB_OWNER: string;
   GITHUB_REPO: string;
@@ -32,6 +36,82 @@ export interface WorkerEnv {
   DISPATCH_EVENT_TYPE?: string;
   /** Payload source label (default 'cf-worker') */
   SOURCE?: string;
+  /** R2 bucket binding — presence selects Profile C direct-write mode
+   * (ADR-006 §2; ticket #100) */
+  STATUS_BUCKET?: R2BucketLike;
+  /** Optional display metadata for regenerate (JSON EntityRef[]);
+   * defaults to {name, type:'system'} derived from TARGETS */
+  ENTITIES?: string;
+  SITE_TITLE?: string;
+  SITE_URL?: string;
+}
+
+/**
+ * Minimal structural view of Cloudflare's R2Bucket — declared locally
+ * so the package needs no @cloudflare/workers-types dependency.
+ */
+export interface R2ObjectLike {
+  httpEtag: string;
+  text(): Promise<string>;
+}
+export interface R2BucketLike {
+  get(key: string): Promise<R2ObjectLike | null>;
+  put(
+    key: string,
+    value: string,
+    options?: {
+      onlyIf?: {etagMatches?: string; etagDoesNotMatch?: string};
+      httpMetadata?: {contentType?: string};
+    }
+  ): Promise<unknown | null>;
+  list(options: {
+    prefix: string;
+    cursor?: string;
+  }): Promise<{objects: Array<{key: string}>; truncated: boolean; cursor?: string}>;
+  delete(key: string): Promise<void>;
+}
+
+/**
+ * ObjectStore over the native R2 binding (no S3 API, no credentials —
+ * the ADR-006 §2 trust model: the Worker holds only a bucket binding).
+ * R2 conditional puts RETURN NULL on precondition failure instead of
+ * throwing; mapped to PreconditionFailedError so the §3 retry in
+ * regenerateDerivedR2 works identically on both planes.
+ */
+export class BindingObjectStore implements ObjectStore {
+  constructor(private readonly bucket: R2BucketLike) {}
+
+  async get(key: string): Promise<StoredObject | null> {
+    const object = await this.bucket.get(key);
+    if (!object) return null;
+    return {body: await object.text(), etag: object.httpEtag};
+  }
+
+  async put(key: string, body: string, options: PutOptions = {}): Promise<{etag: string}> {
+    const result = await this.bucket.put(key, body, {
+      ...(options.ifMatch ? {onlyIf: {etagMatches: options.ifMatch}} : {}),
+      ...(options.ifNoneMatch ? {onlyIf: {etagDoesNotMatch: options.ifNoneMatch}} : {}),
+      httpMetadata: {contentType: options.contentType ?? 'application/json'},
+    });
+    if (result === null) throw new PreconditionFailedError(key);
+    const written = await this.bucket.get(key);
+    return {etag: written?.httpEtag ?? ''};
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    const keys: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await this.bucket.list({prefix, ...(cursor ? {cursor} : {})});
+      keys.push(...page.objects.map(o => o.key));
+      cursor = page.truncated ? page.cursor : undefined;
+    } while (cursor);
+    return keys;
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.bucket.delete(key);
+  }
 }
 
 type FetchLike = typeof fetch;
@@ -118,6 +198,89 @@ export interface WorkerProbeResult {
   dispatched: boolean;
 }
 
+function entitiesOf(env: WorkerEnv, targets: CheckTarget[]): EntityRef[] {
+  if (env.ENTITIES) {
+    const parsed = JSON.parse(env.ENTITIES) as EntityRef[];
+    if (!Array.isArray(parsed) || parsed.some(e => !e?.name || !e?.type)) {
+      throw new Error('ENTITIES must be a JSON array of {name, type, displayName?}');
+    }
+    return parsed;
+  }
+  return targets.map(t => ({name: t.system, type: 'system' as const}));
+}
+
+/**
+ * Profile C probe cycle (ADR-006 §2): checks → immutable batch →
+ * §3-ordered regenerate, all through the bucket binding. Zero GitHub
+ * Actions, zero write credentials outside the binding.
+ */
+export async function runWorkerProbeR2(
+  env: WorkerEnv,
+  deps: WorkerDeps = {}
+): Promise<{readings: CompactReading[]; attempts: number}> {
+  if (!env.STATUS_BUCKET) throw new Error('runWorkerProbeR2 requires the STATUS_BUCKET binding');
+  if (!env.TARGETS) throw new Error('worker env TARGETS is not set');
+  const targets = parseTargets(env.TARGETS);
+  const readings = await runChecks(targets, {fetchImpl: deps.fetchImpl, now: deps.now});
+  const store = new BindingObjectStore(env.STATUS_BUCKET);
+  const generatedAt = new Date(deps.now ?? Date.now()).toISOString();
+  await writeReadingsBatch(store, readings, generatedAt, crypto.randomUUID().slice(0, 8));
+  const result = await regenerateDerivedR2(store, {
+    generatedAt,
+    generatedBy: 'stentorosaur-worker',
+    entities: entitiesOf(env, targets),
+    siteTitle: env.SITE_TITLE ?? 'System Status',
+    siteUrl: env.SITE_URL ?? `https://github.com/${env.GITHUB_OWNER ?? 'unknown'}/${env.GITHUB_REPO ?? 'unknown'}`,
+  });
+  return {readings, attempts: result.attempts};
+}
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, HEAD, OPTIONS',
+  'access-control-allow-headers': 'if-none-match',
+};
+
+/**
+ * Serving route (ADR-006 §2): GET/HEAD status/v1/* from the bucket with
+ * Cache-Control + strong ETag + 304 + CORS. MUST be fronted by a
+ * Cloudflare custom domain so the CDN absorbs client polls (council
+ * condition 4) — the wrangler template documents this as REQUIRED.
+ */
+export async function serveStatusV1(request: Request, env: WorkerEnv): Promise<Response> {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, {status: 204, headers: CORS_HEADERS});
+  }
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return new Response('method not allowed', {status: 405, headers: CORS_HEADERS});
+  }
+  if (!env.STATUS_BUCKET) {
+    return new Response('no bucket bound', {status: 404, headers: CORS_HEADERS});
+  }
+  const path = new URL(request.url).pathname.replace(/^\/+/, '');
+  if (!path.startsWith(`${V1}/`)) {
+    return new Response('not found', {status: 404, headers: CORS_HEADERS});
+  }
+  const object = await env.STATUS_BUCKET.get(path);
+  if (!object) return new Response('not found', {status: 404, headers: CORS_HEADERS});
+  const etag = object.httpEtag;
+  const headers: Record<string, string> = {
+    ...CORS_HEADERS,
+    'cache-control': 'public, max-age=60',
+    etag,
+    'content-type': path.endsWith('.atom')
+      ? 'application/atom+xml'
+      : path.endsWith('.jsonl')
+        ? 'application/x-ndjson'
+        : 'application/json',
+  };
+  if (request.headers.get('if-none-match') === etag) {
+    return new Response(null, {status: 304, headers});
+  }
+  const body = request.method === 'HEAD' ? null : await object.text();
+  return new Response(body, {status: 200, headers});
+}
+
 export async function runWorkerProbe(env: WorkerEnv, deps: WorkerDeps = {}): Promise<WorkerProbeResult> {
   for (const key of ['GITHUB_TOKEN', 'GITHUB_OWNER', 'GITHUB_REPO', 'TARGETS'] as const) {
     if (!env[key]) throw new Error(`worker env ${key} is not set`);
@@ -144,7 +307,15 @@ export async function runWorkerProbe(env: WorkerEnv, deps: WorkerDeps = {}): Pro
  */
 const worker = {
   async scheduled(_event: unknown, env: WorkerEnv): Promise<void> {
-    await runWorkerProbe(env);
+    // Binding present → Profile C direct write; absent → §6 dispatch.
+    if (env.STATUS_BUCKET) {
+      await runWorkerProbeR2(env);
+    } else {
+      await runWorkerProbe(env);
+    }
+  },
+  async fetch(request: Request, env: WorkerEnv): Promise<Response> {
+    return serveStatusV1(request, env);
   },
 };
 

--- a/packages/probe/src/worker.ts
+++ b/packages/probe/src/worker.ts
@@ -63,7 +63,7 @@ export interface R2BucketLike {
       onlyIf?: {etagMatches?: string; etagDoesNotMatch?: string};
       httpMetadata?: {contentType?: string};
     }
-  ): Promise<unknown | null>;
+  ): Promise<R2ObjectLike | null>;
   list(options: {
     prefix: string;
     cursor?: string;
@@ -94,8 +94,7 @@ export class BindingObjectStore implements ObjectStore {
       httpMetadata: {contentType: options.contentType ?? 'application/json'},
     });
     if (result === null) throw new PreconditionFailedError(key);
-    const written = await this.bucket.get(key);
-    return {etag: written?.httpEtag ?? ''};
+    return {etag: result.httpEtag};
   }
 
   async list(prefix: string): Promise<string[]> {
@@ -200,11 +199,16 @@ export interface WorkerProbeResult {
 
 function entitiesOf(env: WorkerEnv, targets: CheckTarget[]): EntityRef[] {
   if (env.ENTITIES) {
-    const parsed = JSON.parse(env.ENTITIES) as EntityRef[];
-    if (!Array.isArray(parsed) || parsed.some(e => !e?.name || !e?.type)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(env.ENTITIES);
+    } catch {
       throw new Error('ENTITIES must be a JSON array of {name, type, displayName?}');
     }
-    return parsed;
+    if (!Array.isArray(parsed) || (parsed as EntityRef[]).some(e => !e?.name || !e?.type)) {
+      throw new Error('ENTITIES must be a JSON array of {name, type, displayName?}');
+    }
+    return parsed as EntityRef[];
   }
   return targets.map(t => ({name: t.system, type: 'system' as const}));
 }

--- a/packages/probe/src/worker.ts
+++ b/packages/probe/src/worker.ts
@@ -202,10 +202,15 @@ function entitiesOf(env: WorkerEnv, targets: CheckTarget[]): EntityRef[] {
     let parsed: unknown;
     try {
       parsed = JSON.parse(env.ENTITIES);
-    } catch {
-      throw new Error('ENTITIES must be a JSON array of {name, type, displayName?}');
+    } catch (err) {
+      throw new Error(
+        `ENTITIES must be a JSON array of {name, type, displayName?}: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
-    if (!Array.isArray(parsed) || (parsed as EntityRef[]).some(e => !e?.name || !e?.type)) {
+    if (
+      !Array.isArray(parsed) ||
+      (parsed as unknown[]).some(e => !(e as EntityRef)?.name || !(e as EntityRef)?.type)
+    ) {
       throw new Error('ENTITIES must be a JSON array of {name, type, displayName?}');
     }
     return parsed as EntityRef[];


### PR DESCRIPTION
Closes #100 (epic #97, ADR-006 §2)

Profile C's Worker half: direct R2 writes through a bucket binding (no credentials beyond the binding) and the serving route.

## Key pieces

- **Workers-safe core entry** `@stentorosaur/core/summary` — the jsdom sanitizer stays in `./server` (which re-exports summary for back-compat); the §7 runbook moved to a server-only module. A **bundle-graph guard test** walks the compiled worker module graph and fails if jsdom ever becomes reachable.
- **BindingObjectStore** — the native-binding ObjectStore; null-on-precondition mapped to `PreconditionFailedError`, so the council's §3 summary-commit retry is plane-agnostic.
- **runWorkerProbeR2** — checks → immutable batch → §3-ordered regenerate; binding presence selects the mode in `scheduled()` (dispatch mode unchanged).
- **serveStatusV1** — Cache-Control/ETag/304/CORS per the §4 client protocol; 405/404 guards.
- **wrangler-r2.toml** with the council-mandated **custom-domain-REQUIRED** route (workers.dev serving forbidden) + budget formula; README Profile C section.

Probe 138 green (10 new), core 73, plugin 325, build + typecheck green.