### PR TITLE
feat: migrate --to r2 / --to git plane portability (#102)

### DIFF
--- a/packages/probe/__tests__/cli.test.ts
+++ b/packages/probe/__tests__/cli.test.ts
@@ -11,7 +11,8 @@ import {parseSummary} from '@stentorosaur/core';
 import {loadConfig} from '../src/config-loader';
 import {reRenderFromRaw} from '../src/regenerate-from-raw';
 import {writeIncidentInputs, writeRawIssueBody, readIncidentInputs} from '../src/inputs';
-import {main} from '../src/cli';
+import {MemoryObjectStore} from '../src/object-store';
+import {main, setObjectStoreFactory} from '../src/cli';
 
 let tmp: string;
 beforeEach(() => {
@@ -223,6 +224,46 @@ describe('stentorosaur doctor (r2 mode, ticket #101)', () => {
       expect(warnSpy.mock.calls.flat().join(' ')).toMatch(/no compaction-state\.json yet/);
     } finally {
       warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('stentorosaur migrate --to (plane portability, ticket #102)', () => {
+  const R2_CONFIG = `module.exports = {owner: 'o', repo: 'r',
+    entities: [{name: 'api', type: 'system'}],
+    dataPlane: {kind: 'r2', bucket: 'status',
+      endpoint: 'https://acc.r2.cloudflarestorage.com',
+      publicBaseUrl: 'https://status.example.com'}};`;
+
+  it('rejects an unknown --to target', async () => {
+    fs.writeFileSync(path.join(tmp, 'stentorosaur.config.js'), R2_CONFIG);
+    expect(await main(['migrate', '--config', tmp, '--to', 'ftp'])).toBe(1);
+  });
+
+  it('refuses plane migration on a git-only config', async () => {
+    fs.writeFileSync(path.join(tmp, 'stentorosaur.config.js'), VALID_CONFIG);
+    expect(await main(['migrate', '--config', tmp, '--to', 'r2'])).toBe(1);
+  });
+
+  it('--to r2 --dry-run plans against the store without writing', async () => {
+    fs.writeFileSync(path.join(tmp, 'stentorosaur.config.js'), R2_CONFIG);
+    const archiveDir = path.join(tmp, 'status', 'v1', 'archives', '2026', '07');
+    fs.mkdirSync(archiveDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(archiveDir, 'history-2026-07-01.jsonl'),
+      '{"t":1782900000000,"svc":"api","state":"up","code":200,"lat":5}\n'
+    );
+    const store = new MemoryObjectStore();
+    setObjectStoreFactory(() => store);
+    try {
+      expect(
+        await main(['migrate', '--config', tmp, '--workdir', tmp, '--to', 'r2', '--dry-run'])
+      ).toBe(0);
+      expect(store.keys()).toEqual([]); // nothing written
+    } finally {
+      setObjectStoreFactory(() => {
+        throw new Error('factory reset');
+      });
     }
   });
 });

--- a/packages/probe/__tests__/cli.test.ts
+++ b/packages/probe/__tests__/cli.test.ts
@@ -266,6 +266,23 @@ describe('stentorosaur migrate --to (plane portability, ticket #102)', () => {
       });
     }
   });
+
+  it('--to git --dry-run reports the plan and leaves the workdir untouched', async () => {
+    fs.writeFileSync(path.join(tmp, 'stentorosaur.config.js'), R2_CONFIG);
+    const store = new MemoryObjectStore();
+    await store.put('status/v1/inputs/incidents.json', '[]');
+    setObjectStoreFactory(() => store);
+    try {
+      expect(
+        await main(['migrate', '--config', tmp, '--workdir', tmp, '--to', 'git', '--dry-run'])
+      ).toBe(0);
+      expect(fs.existsSync(path.join(tmp, 'status'))).toBe(false); // nothing written
+    } finally {
+      setObjectStoreFactory(() => {
+        throw new Error('factory reset');
+      });
+    }
+  });
 });
 
 describe('stentorosaur probe --no-push (local pipeline)', () => {

--- a/packages/probe/__tests__/plane-migrate.test.ts
+++ b/packages/probe/__tests__/plane-migrate.test.ts
@@ -209,6 +209,37 @@ describe('zero-loss details', () => {
     expect(store.keys().some(k => k.endsWith('.gz'))).toBe(false);
   });
 
+  it('a corrupt target-side .gz never aborts r2 → git (Council r=1)', async () => {
+    const store = new MemoryObjectStore();
+    const body = `${JSON.stringify(reading('api', '2026-07-01T10:00:00.000Z'))}\n`;
+    await store.put(`${V1}/archives/2026/07/history-2026-07-01.jsonl`, body);
+
+    const backDir = path.join(tmp, 'back');
+    const gzFile = `${archiveFile(backDir, '2026-07-01')}.gz`;
+    fs.mkdirSync(path.dirname(gzFile), {recursive: true});
+    fs.writeFileSync(gzFile, 'not actually gzip');
+
+    const warnings: string[] = [];
+    const report = await migrateR2ToGit(store, backDir, {onWarn: m => warnings.push(m)});
+    expect(warnings.join(' ')).toMatch(/unreadable .*\.gz treated as absent/);
+    expect(report.created).toEqual([`${V1}/archives/2026/07/history-2026-07-01.jsonl`]);
+    expect(fs.readFileSync(archiveFile(backDir, '2026-07-01'), 'utf8')).toBe(body);
+    expect(fs.readFileSync(gzFile, 'utf8')).toBe('not actually gzip'); // left for inspection
+  });
+
+  it('warns about a plain+gz pair in either readdir order (Council r=1)', async () => {
+    const sourceDir = path.join(tmp, 'source');
+    const body = `${JSON.stringify(reading('api', '2026-07-01T10:00:00.000Z'))}\n`;
+    // Plain sorts BEFORE .gz alphabetically — the previously-silent order.
+    seedGitDay(sourceDir, '2026-07-01', [reading('api', '2026-07-01T10:00:00.000Z')]);
+    fs.writeFileSync(`${archiveFile(sourceDir, '2026-07-01')}.gz`, zlib.gzipSync('{"stale":1}\n'));
+
+    const warnings: string[] = [];
+    const tree = collectGitTree(sourceDir, m => warnings.push(m));
+    expect(warnings.join(' ')).toMatch(/both plain and gzipped/);
+    expect(tree.get(`${V1}/archives/2026/07/history-2026-07-01.jsonl`)).toBe(body); // plain won
+  });
+
   it('divergent archives merge by (svc, t) with deterministic order', async () => {
     const sourceDir = path.join(tmp, 'source');
     seedGitDay(sourceDir, '2026-07-01', [

--- a/packages/probe/__tests__/plane-migrate.test.ts
+++ b/packages/probe/__tests__/plane-migrate.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Plane portability (ADR-006 §6; ticket #102): golden round-trip,
+ * idempotence both directions, dry-run writes nothing, and the
+ * compaction-buffer fold on r2→git.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import {buildDailyRollups} from '@stentorosaur/core/summary';
+import type {CompactReading} from '@stentorosaur/core';
+import {MemoryObjectStore} from '../src/object-store';
+import {V1, writeReadingsBatch} from '../src/r2-plane';
+import {collectGitTree, migrateGitToR2, migrateR2ToGit} from '../src/plane-migrate';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'plane-migrate-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, {recursive: true, force: true});
+});
+
+const reading = (svc: string, iso: string, lat = 40): CompactReading => ({
+  t: Date.parse(iso),
+  svc,
+  state: 'up',
+  code: 200,
+  lat,
+});
+
+function archiveFile(workdir: string, date: string): string {
+  const [y, m] = date.split('-');
+  return path.join(workdir, 'status', 'v1', 'archives', y, m, `history-${date}.jsonl`);
+}
+
+/** Write a day archive the way the probe/compactor would: one JSON per
+ * line, (t, svc)-sorted, trailing newline. */
+function seedGitDay(workdir: string, date: string, readings: CompactReading[]): string {
+  const file = archiveFile(workdir, date);
+  fs.mkdirSync(path.dirname(file), {recursive: true});
+  const sorted = [...readings].sort((a, b) => a.t - b.t || a.svc.localeCompare(b.svc));
+  const body = sorted.map(r => JSON.stringify(r)).join('\n') + '\n';
+  fs.writeFileSync(file, body);
+  return body;
+}
+
+/** 90 days × 3 entities × 2 readings/day. */
+function seedNinetyDays(workdir: string): Map<string, string> {
+  const bodies = new Map<string, string>();
+  const start = Date.parse('2026-04-01T00:00:00Z');
+  for (let d = 0; d < 90; d++) {
+    const date = new Date(start + d * 86_400_000).toISOString().split('T')[0];
+    const readings = ['api', 'web', 'db'].flatMap(svc => [
+      reading(svc, `${date}T06:00:00.000Z`, 20 + d),
+      reading(svc, `${date}T18:00:00.000Z`, 30 + d),
+    ]);
+    bodies.set(`${V1}/archives/${date.slice(0, 4)}/${date.slice(5, 7)}/history-${date}.jsonl`,
+      seedGitDay(workdir, date, readings));
+  }
+  return bodies;
+}
+
+function allGitReadings(workdir: string): CompactReading[] {
+  return [...collectGitTree(workdir).entries()]
+    .filter(([key]) => key.includes('/archives/'))
+    .flatMap(([, body]) =>
+      body.split('\n').filter(l => l.trim()).map(l => JSON.parse(l) as CompactReading)
+    );
+}
+
+describe('golden round-trip (acceptance criterion 1)', () => {
+  it('90 days round-trip git → r2 → git byte-identically with identical rollups', async () => {
+    const sourceDir = path.join(tmp, 'source');
+    const bodies = seedNinetyDays(sourceDir);
+    fs.mkdirSync(path.join(sourceDir, 'status', 'v1', 'inputs'), {recursive: true});
+    fs.writeFileSync(path.join(sourceDir, 'status', 'v1', 'inputs', 'incidents.json'), '[]');
+    fs.mkdirSync(path.join(sourceDir, 'status', 'v1', 'raw'), {recursive: true});
+    fs.writeFileSync(
+      path.join(sourceDir, 'status', 'v1', 'raw', '7.json'),
+      JSON.stringify({schemaVersion: 1, issueNumber: 7, updatedAt: '2026-07-01T00:00:00Z', bodyMarkdown: 'x'})
+    );
+
+    const store = new MemoryObjectStore();
+    const up = await migrateGitToR2(sourceDir, store);
+    expect(up.created).toHaveLength(92); // 90 archives + incidents + raw
+    expect(up.merged).toEqual([]);
+
+    // Every object byte-identical to its source file.
+    for (const [key, body] of bodies) {
+      expect((await store.get(key))!.body).toBe(body);
+    }
+
+    const backDir = path.join(tmp, 'back');
+    const down = await migrateR2ToGit(store, backDir);
+    expect(down.created).toHaveLength(92);
+    expect(down.merged).toEqual([]);
+    for (const [key, body] of bodies) {
+      expect(fs.readFileSync(path.join(backDir, ...key.split('/')), 'utf8')).toBe(body);
+    }
+    expect(fs.readFileSync(path.join(backDir, 'status', 'v1', 'inputs', 'incidents.json'), 'utf8')).toBe('[]');
+
+    // Identical day-level rollups (the ticket #75 golden standard).
+    expect(buildDailyRollups(allGitReadings(backDir))).toEqual(
+      buildDailyRollups(allGitReadings(sourceDir))
+    );
+  });
+});
+
+describe('idempotence (acceptance criterion 2)', () => {
+  it('a re-run in each direction skips everything and writes nothing', async () => {
+    const sourceDir = path.join(tmp, 'source');
+    seedGitDay(sourceDir, '2026-07-01', [reading('api', '2026-07-01T10:00:00.000Z')]);
+    const store = new MemoryObjectStore();
+
+    await migrateGitToR2(sourceDir, store);
+    const opsBefore = store.ops.length;
+    const second = await migrateGitToR2(sourceDir, store);
+    expect(second.created).toEqual([]);
+    expect(second.merged).toEqual([]);
+    expect(second.skipped).toHaveLength(1);
+    expect(store.ops.slice(opsBefore).filter(op => op.op === 'put')).toEqual([]);
+
+    const backDir = path.join(tmp, 'back');
+    await migrateR2ToGit(store, backDir);
+    const file = archiveFile(backDir, '2026-07-01');
+    const mtime = fs.statSync(file).mtimeMs;
+    const downSecond = await migrateR2ToGit(store, backDir);
+    expect(downSecond.created).toEqual([]);
+    expect(downSecond.merged).toEqual([]);
+    expect(fs.statSync(file).mtimeMs).toBe(mtime); // untouched
+  });
+});
+
+describe('--dry-run writes nothing (acceptance criterion 3)', () => {
+  it('git → r2 dry run performs zero puts but reports the full plan', async () => {
+    const sourceDir = path.join(tmp, 'source');
+    seedGitDay(sourceDir, '2026-07-01', [reading('api', '2026-07-01T10:00:00.000Z')]);
+    const store = new MemoryObjectStore();
+    const report = await migrateGitToR2(sourceDir, store, {dryRun: true});
+    expect(report.created).toHaveLength(1);
+    expect(store.ops.filter(op => op.op === 'put')).toEqual([]);
+    expect(store.keys()).toEqual([]);
+  });
+
+  it('r2 → git dry run leaves the filesystem untouched', async () => {
+    const store = new MemoryObjectStore();
+    await store.put(`${V1}/archives/2026/07/history-2026-07-01.jsonl`, `${JSON.stringify(reading('api', '2026-07-01T10:00:00.000Z'))}\n`);
+    await writeReadingsBatch(store, [reading('api', '2026-07-02T10:00:00.000Z')], '2026-07-02T10:00:00.000Z', 'r1');
+    const backDir = path.join(tmp, 'back');
+    const report = await migrateR2ToGit(store, backDir, {dryRun: true});
+    expect(report.created).toHaveLength(1);
+    expect(report.foldedBatches).toBe(1);
+    expect(fs.existsSync(path.join(backDir, 'status'))).toBe(false);
+  });
+});
+
+describe('zero-loss details', () => {
+  it('r2 → git folds not-yet-compacted readings batches into day archives', async () => {
+    const store = new MemoryObjectStore();
+    await store.put(
+      `${V1}/archives/2026/07/history-2026-07-01.jsonl`,
+      `${JSON.stringify(reading('api', '2026-07-01T10:00:00.000Z'))}\n`
+    );
+    // Two batches inside the compaction buffer, one overlapping the day archive.
+    await writeReadingsBatch(store, [
+      reading('api', '2026-07-01T10:00:00.000Z', 99), // dup: archive wins
+      reading('api', '2026-07-01T23:55:00.000Z'),
+    ], '2026-07-01T23:55:00.000Z', 'r1');
+    await writeReadingsBatch(store, [reading('api', '2026-07-02T00:05:00.000Z')], '2026-07-02T00:05:00.000Z', 'r2');
+
+    const backDir = path.join(tmp, 'back');
+    const report = await migrateR2ToGit(store, backDir);
+    expect(report.foldedBatches).toBe(2);
+
+    const day1 = fs.readFileSync(archiveFile(backDir, '2026-07-01'), 'utf8').trim().split('\n').map(l => JSON.parse(l));
+    expect(day1).toHaveLength(2);
+    expect(day1[0].lat).toBe(40); // archive won the (svc, t) collision
+    const day2 = fs.readFileSync(archiveFile(backDir, '2026-07-02'), 'utf8').trim().split('\n');
+    expect(day2).toHaveLength(1);
+  });
+
+  it('derived and operational objects are never copied to git', async () => {
+    const store = new MemoryObjectStore();
+    await store.put(`${V1}/summary.json`, '{}');
+    await store.put(`${V1}/entities/api.json`, '{}');
+    await store.put(`${V1}/incidents.atom`, '<feed/>');
+    await store.put(`${V1}/compaction-state.json`, '{}');
+    await store.put(`${V1}/inputs/incidents.json`, '[]');
+
+    const backDir = path.join(tmp, 'back');
+    const report = await migrateR2ToGit(store, backDir);
+    expect(report.created).toEqual([`${V1}/inputs/incidents.json`]);
+    expect(fs.existsSync(path.join(backDir, 'status', 'v1', 'summary.json'))).toBe(false);
+    expect(fs.existsSync(path.join(backDir, 'status', 'v1', 'compaction-state.json'))).toBe(false);
+  });
+
+  it('gzipped git archives are decompressed for r2 (plain .jsonl keys only)', async () => {
+    const sourceDir = path.join(tmp, 'source');
+    const body = `${JSON.stringify(reading('api', '2026-07-01T10:00:00.000Z'))}\n`;
+    const file = archiveFile(sourceDir, '2026-07-01');
+    fs.mkdirSync(path.dirname(file), {recursive: true});
+    fs.writeFileSync(`${file}.gz`, zlib.gzipSync(body));
+
+    const store = new MemoryObjectStore();
+    await migrateGitToR2(sourceDir, store);
+    expect((await store.get(`${V1}/archives/2026/07/history-2026-07-01.jsonl`))!.body).toBe(body);
+    expect(store.keys().some(k => k.endsWith('.gz'))).toBe(false);
+  });
+
+  it('divergent archives merge by (svc, t) with deterministic order', async () => {
+    const sourceDir = path.join(tmp, 'source');
+    seedGitDay(sourceDir, '2026-07-01', [
+      reading('api', '2026-07-01T10:00:00.000Z', 7),
+      reading('web', '2026-07-01T11:00:00.000Z'),
+    ]);
+    const store = new MemoryObjectStore();
+    const key = `${V1}/archives/2026/07/history-2026-07-01.jsonl`;
+    await store.put(key, [
+      JSON.stringify(reading('api', '2026-07-01T10:00:00.000Z', 99)), // collision: target wins
+      JSON.stringify(reading('db', '2026-07-01T12:00:00.000Z')),
+    ].join('\n') + '\n');
+
+    const report = await migrateGitToR2(sourceDir, store);
+    expect(report.merged).toEqual([key]);
+    const lines = (await store.get(key))!.body.trim().split('\n').map(l => JSON.parse(l));
+    expect(lines.map(l => l.svc)).toEqual(['api', 'web', 'db']); // (t, svc) order
+    expect(lines[0].lat).toBe(99); // pre-existing target reading preserved
+  });
+
+  it('inputs take the source side whole when they differ', async () => {
+    const sourceDir = path.join(tmp, 'source');
+    fs.mkdirSync(path.join(sourceDir, 'status', 'v1', 'inputs'), {recursive: true});
+    fs.writeFileSync(path.join(sourceDir, 'status', 'v1', 'inputs', 'incidents.json'), '[{"new": true}]');
+    const store = new MemoryObjectStore();
+    await store.put(`${V1}/inputs/incidents.json`, '[{"old": true}]');
+
+    await migrateGitToR2(sourceDir, store);
+    expect((await store.get(`${V1}/inputs/incidents.json`))!.body).toBe('[{"new": true}]');
+  });
+});

--- a/packages/probe/src/cli.ts
+++ b/packages/probe/src/cli.ts
@@ -27,6 +27,8 @@ import {reRenderFromRaw} from './regenerate-from-raw';
 import {fetchStatusIssues, transformIssueInputs, writeIssueInputs} from './update-incidents';
 import {migrateHistoricalData, planMigration} from './migrate';
 import type {MigrationReport} from './migrate';
+import {migrateGitToR2, migrateR2ToGit} from './plane-migrate';
+import type {PlaneMigrationReport} from './plane-migrate';
 import {R2ObjectStore, normalizeBaseUrl} from './object-store';
 import type {ObjectStore} from './object-store';
 import {compactionStateSchema} from './r2-compaction';
@@ -44,6 +46,8 @@ interface CliOptions {
   from: string;
   /** migrate: plan only, write nothing */
   dryRun: boolean;
+  /** migrate: plane portability target ('r2' | 'git', ADR-006 §6) */
+  to?: string;
   /** ingest: path to the repository_dispatch client_payload JSON */
   payload?: string;
 }
@@ -83,6 +87,9 @@ function parseArgs(argv: string[]): {command: string; options: CliOptions} {
         break;
       case '--dry-run':
         options.dryRun = true;
+        break;
+      case '--to':
+        options.to = takeValue('--to', ++i);
         break;
       case '--payload':
         options.payload = takeValue('--payload', ++i);
@@ -526,7 +533,66 @@ function monitorrcToConfigSource(monitorrcPath: string): string {
   );
 }
 
+/** Plane portability (ADR-006 §6): migrate --to r2 / --to git. */
+async function cmdMigratePlane(options: CliOptions): Promise<number> {
+  if (options.to !== 'r2' && options.to !== 'git') {
+    console.error(`--to must be 'r2' or 'git', got '${options.to}'`);
+    return 1;
+  }
+  const config = await loadConfig(options.config);
+  if (config.dataPlane.kind !== 'r2') {
+    console.error(
+      "plane migration needs dataPlane {kind: 'r2', …} in the config — it names the bucket to copy to/from (ADR-006 §6)"
+    );
+    return 1;
+  }
+  const store = objectStoreFactory(config);
+  const onWarn = (message: string) => console.warn(`  ⚠ ${message}`);
+  const printReport = (direction: string, report: PlaneMigrationReport) => {
+    const verb = options.dryRun ? 'would ' : '';
+    console.log(`${options.dryRun ? 'dry run — nothing written. ' : ''}${direction}:`);
+    console.log(`  ${verb}create ${report.created.length}, merge ${report.merged.length}, skip ${report.skipped.length} (identical)`);
+    for (const key of report.created) console.log(`    + ${key}`);
+    for (const key of report.merged) console.log(`    ~ ${key}`);
+    if (report.foldedBatches > 0) console.log(`  ${verb}fold ${report.foldedBatches} readings batch(es) into day archives`);
+    if (report.corruptLines > 0) console.log(`  ${report.corruptLines} corrupt line(s) skipped`);
+  };
+
+  if (options.to === 'r2') {
+    // Source of truth: the git data-branch tree at --workdir.
+    if (!fs.existsSync(path.join(options.workdir, 'status', 'v1'))) {
+      console.error(`no status/v1 tree at ${options.workdir} — point --workdir at a data-branch checkout`);
+      return 1;
+    }
+    const report = await migrateGitToR2(options.workdir, store, {dryRun: options.dryRun, onWarn});
+    printReport('git → r2', report);
+    if (!options.dryRun) {
+      await regenerateDerivedR2(store, {
+        ...regenOptions(config, new Date().toISOString()),
+        generatedBy: 'stentorosaur-migrate',
+        onWarn,
+      });
+      console.log('derived objects regenerated on r2 (§3 write order)');
+    }
+    return 0;
+  }
+
+  // --to git: bucket → data branch commit (withDataBranch regenerates).
+  if (options.dryRun) {
+    const report = await migrateR2ToGit(store, options.workdir, {dryRun: true, onWarn});
+    printReport('r2 → git', report);
+    return 0;
+  }
+  let report: PlaneMigrationReport | null = null;
+  await withDataBranch(options, config, 'migrate: r2 → git data branch (ADR-006 §6)', async dir => {
+    report = await migrateR2ToGit(store, dir, {onWarn});
+  });
+  if (report) printReport('r2 → git', report);
+  return 0;
+}
+
 async function cmdMigrate(options: CliOptions): Promise<number> {
+  if (options.to !== undefined) return cmdMigratePlane(options);
   const legacyDir = path.resolve(options.from);
 
   // Config detection must respect --config, which typically points at
@@ -622,7 +688,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
       case 'ingest':
         return await cmdIngest(options);
       default:
-        console.log('usage: stentorosaur <init|doctor|probe|update-incidents|regenerate|migrate|ingest> [--config <file-or-dir>] [--workdir <dir>] [--branch <name>] [--no-push] [--from <legacy-dir>] [--dry-run] [--payload <file>]');
+        console.log('usage: stentorosaur <init|doctor|probe|update-incidents|regenerate|migrate|ingest> [--config <file-or-dir>] [--workdir <dir>] [--branch <name>] [--no-push] [--from <legacy-dir>] [--to <r2|git>] [--dry-run] [--payload <file>]');
         return command === 'help' ? 0 : 1;
     }
   } catch (error) {

--- a/packages/probe/src/index.ts
+++ b/packages/probe/src/index.ts
@@ -18,5 +18,6 @@ export * from './migrate';
 export * from './object-store';
 export * from './r2-plane';
 export * from './r2-compaction';
+export * from './plane-migrate';
 export * from './r2-raw-rerender';
 export * from './cli';

--- a/packages/probe/src/plane-migrate.ts
+++ b/packages/probe/src/plane-migrate.ts
@@ -105,11 +105,12 @@ export function collectGitTree(
           .relative(workdir, path.join(dir, match[1]))
           .split(path.sep)
           .join('/');
-        if (bodies.has(key) && !match[2]) {
+        if (bodies.has(key)) {
           // Both .jsonl and .jsonl.gz for one day: plain wins (fresher).
+          // Warn in BOTH visit orders (Council PR #109 r=1) — readdir
+          // order is not guaranteed.
           onWarn(`${key} exists both plain and gzipped — using the plain file`);
-        } else if (bodies.has(key)) {
-          continue;
+          if (match[2]) continue; // plain already loaded; skip the gz
         }
         try {
           bodies.set(
@@ -245,14 +246,32 @@ export async function migrateR2ToGit(
     }
   }
 
-  const fileOf = (key: string) => path.join(workdir, ...key.split('/'));
+  const fileOf = (key: string) => {
+    // Defense-in-depth (Council PR #109 r=1): every key that reaches
+    // here is regex-whitelisted, but a path write must never depend on
+    // that staying true.
+    const parts = key.split('/');
+    if (parts.some(p => p === '' || p === '.' || p === '..')) {
+      throw new Error(`refusing unsafe key path: ${key}`);
+    }
+    return path.join(workdir, ...parts);
+  };
   const readFile: ReadTarget = async key => {
     const file = fileOf(key);
     if (fs.existsSync(file)) return fs.readFileSync(file, 'utf8');
     // A gzipped-only day on the git side still counts as the target
     // content — merge into it and write plain (the .gz is left alone).
     if (key.endsWith('.jsonl') && fs.existsSync(`${file}.gz`)) {
-      return zlib.gunzipSync(fs.readFileSync(`${file}.gz`)).toString('utf8');
+      try {
+        return zlib.gunzipSync(fs.readFileSync(`${file}.gz`)).toString('utf8');
+      } catch (error) {
+        // Corrupt .gz must not abort the migration (Council PR #109
+        // r=1, never-fatal rule): treat the target as absent — the
+        // plain .jsonl gets written from source, the .gz stays for
+        // manual inspection.
+        onWarn(`unreadable ${key}.gz treated as absent (left in place): ${String(error).slice(0, 120)}`);
+        return null;
+      }
     }
     return null;
   };

--- a/packages/probe/src/plane-migrate.ts
+++ b/packages/probe/src/plane-migrate.ts
@@ -1,0 +1,315 @@
+/**
+ * Profile portability: `migrate --to r2` / `--to git` (ADR-006 §6;
+ * epic #97 ticket #102). Copies the status/v1 INPUT tree between the
+ * git data branch and an R2 bucket with the same zero-loss guarantees
+ * as the 0.x→v1 migration (ticket #75 precedent).
+ *
+ * Rules, per object:
+ * - target missing → VERBATIM copy (byte identity is what makes the
+ *   golden round-trip test meaningful)
+ * - target identical → skip
+ * - target differs → archives are MERGED with the compaction merge
+ *   (deduped by (svc, t), deterministic order, unparseable target
+ *   lines preserved); inputs/ and raw/ take the SOURCE side whole (the
+ *   direction of the migration names the source of truth)
+ * - derived objects (summary.json, entities/, incidents.atom) and the
+ *   compaction-state are NEVER copied — the target regenerates them
+ *   under its own write-order rules (§3 on r2, git commit on git)
+ * - r2→git additionally FOLDS not-yet-compacted readings/ batches into
+ *   the day archives so the compaction buffer window is not lost
+ *
+ * Both directions are idempotent: a re-run classifies everything as
+ * 'skipped' and writes nothing.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import {compactReadingSchema} from '@stentorosaur/core';
+import type {CompactReading} from '@stentorosaur/core';
+import type {ObjectStore} from './object-store';
+import {V1} from './r2-plane';
+import {mergeArchiveBytes} from './r2-compaction';
+
+export interface PlaneMigrationReport {
+  created: string[];
+  merged: string[];
+  skipped: string[];
+  corruptLines: number;
+  /** r2→git only: readings/ batches folded into day archives */
+  foldedBatches: number;
+}
+
+export interface PlaneMigrateOptions {
+  /** Plan only — read everything, write nothing */
+  dryRun?: boolean;
+  onWarn?: (message: string) => void;
+}
+
+const ARCHIVE_KEY_RE = /^status\/v1\/archives\/(\d{4})\/(\d{2})\/history-(\d{4}-\d{2}-\d{2})\.jsonl$/;
+
+function isCopyableKey(key: string): 'archive' | 'input' | 'raw' | null {
+  if (ARCHIVE_KEY_RE.test(key)) return 'archive';
+  if (key === `${V1}/inputs/incidents.json` || key === `${V1}/inputs/maintenance.json`) {
+    return 'input';
+  }
+  if (/^status\/v1\/raw\/[^/]+\.json$/.test(key)) return 'raw';
+  return null;
+}
+
+function parseReadings(
+  body: string,
+  label: string,
+  onWarn: (message: string) => void
+): {readings: CompactReading[]; corrupt: number} {
+  const readings: CompactReading[] = [];
+  let corrupt = 0;
+  for (const line of body.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = compactReadingSchema.safeParse(JSON.parse(line));
+      if (parsed.success) {
+        readings.push(parsed.data);
+      } else {
+        corrupt++;
+      }
+    } catch {
+      corrupt++;
+    }
+  }
+  if (corrupt > 0) onWarn(`${corrupt} corrupt line(s) in ${label} skipped`);
+  return {readings, corrupt};
+}
+
+/** Walk the git-side status/v1 tree into key → body (archives
+ * decompressed: the r2 plane stores plain .jsonl only). */
+export function collectGitTree(
+  workdir: string,
+  onWarn: (message: string) => void = () => {}
+): Map<string, string> {
+  const bodies = new Map<string, string>();
+  const root = path.join(workdir, 'status', 'v1');
+
+  const archivesDir = path.join(root, 'archives');
+  if (fs.existsSync(archivesDir)) {
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        const match = entry.name.match(/^(history-\d{4}-\d{2}-\d{2}\.jsonl)(\.gz)?$/);
+        if (!match) continue;
+        const key = path
+          .relative(workdir, path.join(dir, match[1]))
+          .split(path.sep)
+          .join('/');
+        if (bodies.has(key) && !match[2]) {
+          // Both .jsonl and .jsonl.gz for one day: plain wins (fresher).
+          onWarn(`${key} exists both plain and gzipped — using the plain file`);
+        } else if (bodies.has(key)) {
+          continue;
+        }
+        try {
+          bodies.set(
+            key,
+            match[2]
+              ? zlib.gunzipSync(fs.readFileSync(full)).toString('utf8')
+              : fs.readFileSync(full, 'utf8')
+          );
+        } catch (error) {
+          onWarn(`unreadable archive ${full}: ${String(error).slice(0, 120)}`);
+        }
+      }
+    };
+    walk(archivesDir);
+  }
+
+  for (const rel of ['inputs/incidents.json', 'inputs/maintenance.json']) {
+    const file = path.join(root, rel);
+    if (fs.existsSync(file)) bodies.set(`${V1}/${rel}`, fs.readFileSync(file, 'utf8'));
+  }
+  const rawDir = path.join(root, 'raw');
+  if (fs.existsSync(rawDir)) {
+    for (const f of fs.readdirSync(rawDir).filter(f => f.endsWith('.json'))) {
+      bodies.set(`${V1}/raw/${f}`, fs.readFileSync(path.join(rawDir, f), 'utf8'));
+    }
+  }
+  return bodies;
+}
+
+type ReadTarget = (key: string) => Promise<string | null>;
+type WriteTarget = (key: string, body: string) => Promise<void>;
+
+/** The shared per-object copy protocol (see module header). */
+async function copyTree(
+  source: Map<string, string>,
+  readTarget: ReadTarget,
+  writeTarget: WriteTarget,
+  options: PlaneMigrateOptions
+): Promise<PlaneMigrationReport> {
+  const {dryRun = false, onWarn = () => {}} = options;
+  const report: PlaneMigrationReport = {
+    created: [],
+    merged: [],
+    skipped: [],
+    corruptLines: 0,
+    foldedBatches: 0,
+  };
+
+  for (const [key, sourceBody] of [...source.entries()].sort()) {
+    const kind = isCopyableKey(key);
+    if (!kind) {
+      onWarn(`${key} is not a copyable status/v1 input — skipped`);
+      continue;
+    }
+    const targetBody = await readTarget(key);
+    if (targetBody === null) {
+      report.created.push(key);
+      if (!dryRun) await writeTarget(key, sourceBody);
+      continue;
+    }
+    if (targetBody === sourceBody) {
+      report.skipped.push(key);
+      continue;
+    }
+    if (kind === 'archive') {
+      const {readings, corrupt} = parseReadings(sourceBody, key, onWarn);
+      report.corruptLines += corrupt;
+      const mergedBody = mergeArchiveBytes(targetBody, readings);
+      if (mergedBody === targetBody) {
+        report.skipped.push(key);
+      } else {
+        report.merged.push(key);
+        if (!dryRun) await writeTarget(key, mergedBody);
+      }
+    } else {
+      // inputs/ and raw/: the migration direction names the source of
+      // truth — take the source side whole.
+      report.merged.push(key);
+      if (!dryRun) await writeTarget(key, sourceBody);
+    }
+  }
+  return report;
+}
+
+/**
+ * git → r2: copy archives (decompressed) + inputs + raw into the
+ * bucket. The caller regenerates derived objects afterwards via
+ * regenerateDerivedR2 (§3 write order) — never here, never in dry-run.
+ */
+export async function migrateGitToR2(
+  workdir: string,
+  store: ObjectStore,
+  options: PlaneMigrateOptions = {}
+): Promise<PlaneMigrationReport> {
+  const source = collectGitTree(workdir, options.onWarn);
+  return copyTree(
+    source,
+    async key => (await store.get(key))?.body ?? null,
+    async (key, body) =>
+      void (await store.put(key, body, {
+        contentType: key.endsWith('.jsonl') ? 'application/x-ndjson' : 'application/json',
+      })),
+    options
+  );
+}
+
+/**
+ * r2 → git: copy archives + inputs + raw into the workdir tree, then
+ * FOLD not-yet-compacted readings/ batches into their day archives so
+ * the compaction buffer window survives the move. The caller commits
+ * and regenerates (withDataBranch) — never here, never in dry-run.
+ */
+export async function migrateR2ToGit(
+  store: ObjectStore,
+  workdir: string,
+  options: PlaneMigrateOptions = {}
+): Promise<PlaneMigrationReport> {
+  const {dryRun = false, onWarn = () => {}} = options;
+  const source = new Map<string, string>();
+  const batches: Array<{key: string; body: string}> = [];
+
+  for (const prefix of ['archives/', 'inputs/', 'raw/', 'readings/']) {
+    for (const key of await store.list(`${V1}/${prefix}`)) {
+      const object = await store.get(key);
+      if (!object) continue;
+      if (prefix === 'readings/') {
+        batches.push({key, body: object.body});
+      } else if (isCopyableKey(key)) {
+        source.set(key, object.body);
+      } else {
+        onWarn(`${key} is not a copyable status/v1 input — skipped`);
+      }
+    }
+  }
+
+  const fileOf = (key: string) => path.join(workdir, ...key.split('/'));
+  const readFile: ReadTarget = async key => {
+    const file = fileOf(key);
+    if (fs.existsSync(file)) return fs.readFileSync(file, 'utf8');
+    // A gzipped-only day on the git side still counts as the target
+    // content — merge into it and write plain (the .gz is left alone).
+    if (key.endsWith('.jsonl') && fs.existsSync(`${file}.gz`)) {
+      return zlib.gunzipSync(fs.readFileSync(`${file}.gz`)).toString('utf8');
+    }
+    return null;
+  };
+  const writeFile: WriteTarget = async (key, body) => {
+    const file = fileOf(key);
+    fs.mkdirSync(path.dirname(file), {recursive: true});
+    fs.writeFileSync(file, body);
+  };
+
+  const report = await copyTree(source, readFile, writeFile, options);
+
+  // Fold the compaction-buffer batches (grouped by UTC day) into the
+  // day archives ON DISK — after the archive copies, so the merge sees
+  // the copied content.
+  const byDay = new Map<string, CompactReading[]>();
+  for (const {key, body} of batches) {
+    const stamp = key.match(/readings\/(\d{4}-\d{2}-\d{2})T/)?.[1];
+    if (!stamp) {
+      onWarn(`unrecognized batch key ${key} left behind`);
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      onWarn(`unparseable batch ${key} left behind`);
+      continue;
+    }
+    if (!Array.isArray(parsed)) {
+      onWarn(`malformed batch ${key} left behind`);
+      continue;
+    }
+    let contributed = false;
+    for (const raw of parsed) {
+      const reading = compactReadingSchema.safeParse(raw);
+      if (!reading.success) {
+        report.corruptLines++;
+        continue;
+      }
+      const day = byDay.get(stamp) ?? [];
+      day.push(reading.data);
+      byDay.set(stamp, day);
+      contributed = true;
+    }
+    if (contributed) report.foldedBatches++;
+  }
+  for (const [date, readings] of [...byDay.entries()].sort()) {
+    const [y, m] = date.split('-');
+    const key = `${V1}/archives/${y}/${m}/history-${date}.jsonl`;
+    const existing = await readFile(key);
+    const mergedBody = mergeArchiveBytes(existing, readings);
+    if (mergedBody !== (existing ?? '')) {
+      if (!report.created.includes(key) && !report.merged.includes(key)) {
+        report.merged.push(key);
+      }
+      if (!dryRun) await writeFile(key, mergedBody);
+    }
+  }
+  return report;
+}

--- a/packages/probe/src/r2-compaction.ts
+++ b/packages/probe/src/r2-compaction.ts
@@ -89,8 +89,9 @@ interface DayPlan {
  * lines are PRESERVED verbatim (compaction never destroys data), then
  * the (svc, t)-deduped union of archive readings and batch readings —
  * archive wins on collision — sorted by (t, svc), one JSON per line.
+ * Shared with the plane migration (ticket #102): merging is merging.
  */
-function mergeArchiveBytes(
+export function mergeArchiveBytes(
   existingBody: string | null,
   batchReadings: CompactReading[]
 ): string {


### PR DESCRIPTION
Closes #102

## What

ADR-006 §6 profile portability: `stentorosaur migrate --to r2` / `--to git`, copying the data plane between backends with the ticket #75 zero-loss guarantees.

### Copy protocol (`packages/probe/src/plane-migrate.ts`)
Per object: **target missing → verbatim copy** (byte identity is what makes the golden test meaningful); **identical → skip**; **divergent → archives merge** via the shared compaction merge (`mergeArchiveBytes`: (svc,t)-deduped, deterministic (t,svc) order, unparseable target lines preserved) while **inputs/ and raw/ take the source side whole** (the migration direction names the source of truth). Derived objects (summary, entities/, atom) and `compaction-state.json` are **never copied** — the target regenerates them under its own rules (§3 write order on r2; `withDataBranch` commit on git).

### Zero-loss specifics
- **r2 → git folds not-yet-compacted `readings/` batches** into their day archives, so the compaction-buffer window (≤2 days) survives the move.
- **git → r2 decompresses `.jsonl.gz` archives** to the plain `.jsonl` keys the r2 plane expects; a plain+gz pair prefers plain with a warning.
- Corrupt source lines are counted and skipped, never fatal; malformed batch keys/content are left behind with warnings (same quarantine rule as compaction).

### CLI
- `--to r2`: reads the data-branch tree at `--workdir`, copies, then `regenerateDerivedR2` (summary-last commit point). Read-only on the git side.
- `--to git`: bucket → `withDataBranch` commit (which regenerates); respects `--no-push`.
- `--dry-run` both directions prints the create/merge/skip/fold plan and writes nothing.
- Clear errors: unknown `--to` target; `dataPlane {kind:'git'}` config (the bucket coordinates live in `dataPlane {kind:'r2'}`); missing `status/v1` tree at `--workdir`.

## TDD (12 new tests, acceptance criteria first)
- **Golden (AC 1):** 90 days × 3 entities × 2 readings/day round-trips git→r2→git — every object and file byte-identical, `buildDailyRollups` identical.
- **Idempotence (AC 2):** re-run in each direction: all skipped, zero puts (ops-log assertion), file mtime untouched.
- **Dry-run (AC 3):** zero puts + empty bucket (git→r2); filesystem untouched (r2→git) while still reporting the full plan.
- Buffer fold with (svc,t) collision (archive wins); derived/operational objects never copied; gz decompression; divergent-archive merge determinism; inputs source-wins; CLI `--to ftp` / git-only-config rejections; CLI dry-run through the `setObjectStoreFactory` seam.

Doctor already validates whichever plane `dataPlane.kind` selects (landed in #108).

## Gates
- probe: 169 passed (13 suites); core: 73; plugin: 325
- `npm run build` + `tsc --build` clean