### PR TITLE
docs: ADR-006 closeout — Profile C docs + ADR status flip (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Profile C: R2 object-storage data plane** (ADR-006, epic #97) —
+  optional, zero-Actions monitoring. `dataPlane: {kind: 'r2', …}` in
+  `stentorosaur.config.js` moves the `status/v1` contract into an R2
+  bucket: the Cloudflare Worker probes and writes through a bucket
+  binding (write-order consistency with a summary-last `If-Match`
+  commit point), a serving route publishes it with Cache-Control/ETag/
+  CORS behind a required custom domain, and a daily compaction cron
+  folds probe batches into day archives (fenced, verify-before-delete,
+  crash-safe) with health in `compaction-state.json`. `stentorosaur
+  migrate --to r2 | --to git` moves existing history between profiles
+  losslessly (`--dry-run` plans). `doctor` validates whichever plane
+  the config selects and warns on stale compaction. Defaults are
+  unchanged — git-branch deployments are unaffected.
+- e2e now runs a git + r2 profile matrix asserting identical DOM
+  invariants; new concurrency tests cover regenerate races, compaction
+  races, and torn-state detection (council condition 5).
+
+### Fixed
+
+- `readAllReadings` (r2 plane) reads batches before archives — the
+  reverse order could drop a freshly-compacted day from one regenerate
+  cycle when racing the compaction cron.
+- `StatusHistory` derives its entity-detail URL from the runtime
+  `dataUrl` instead of the hardcoded snapshot path — history pages
+  404'd on deployments without a local snapshot in the build.
+
 ## [1.0.1] - 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,8 +11,26 @@ This repository is a monorepo (see
 | Package | Description |
 |---------|-------------|
 | [`@amiable-dev/docusaurus-plugin-stentorosaur`](packages/docusaurus-plugin-stentorosaur/) | The Docusaurus plugin (published to npm) — **full documentation lives in its [README](packages/docusaurus-plugin-stentorosaur/README.md)** |
-| [`@stentorosaur/core`](packages/core/) | Pure schemas and aggregation logic (in development, epic [#63](https://github.com/amiable-dev/docusaurus-plugin-stentorosaur/issues/63)) |
-| [`@stentorosaur/probe`](packages/probe/) | Monitoring engine and I/O (in development, epic [#63](https://github.com/amiable-dev/docusaurus-plugin-stentorosaur/issues/63)) |
+| [`@stentorosaur/core`](packages/core/) | Pure schemas and aggregation logic |
+| [`@stentorosaur/probe`](packages/probe/) | Monitoring engine, `stentorosaur` CLI, and the Cloudflare Worker probe |
+
+## Deployment profiles
+
+One data contract (`status/v1`), three ways to run it
+([ADR-005](docs/adrs/ADR-005-decoupled-data-plane-and-package-split.md),
+[ADR-006](docs/adrs/ADR-006-low-cost-data-plane-profiles.md)):
+
+| Profile | Probe runs on | Data lives in | Monthly cost driver |
+|---|---|---|---|
+| **A** (default) | GitHub Actions cron | git data branch | Actions minutes: each run bills ≥1 min — `*/5` cron ≈ 8,640 min/month, free on public repos, over the 2,000 free-tier on private |
+| **B** | Cloudflare Worker → `repository_dispatch` → Actions ingest | git data branch | ~288 short ingest runs/day; Worker checks free; no write credential in the Worker |
+| **C** | Cloudflare Worker → R2 bucket binding | R2 bucket (served via a **required custom domain**) | zero Actions in the monitoring loop; R2 class-A writes ≈ `runs_per_day × (N_entities + 3) × 30` — ~11% of the 1M free tier at 5-min cadence with 10 entities |
+
+Incident sync (GitHub issues → incidents) stays on Actions in every
+profile; its cost is a few minutes per incident event. Profiles are
+portable both ways with `stentorosaur migrate --to r2 | --to git`.
+Chooser details and setup runbooks:
+[templates/workflows/README](packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md).
 
 ## Development
 

--- a/docs/adrs/ADR-005-decoupled-data-plane-and-package-split.md
+++ b/docs/adrs/ADR-005-decoupled-data-plane-and-package-split.md
@@ -6,8 +6,8 @@
 council conditions 2026-07-12, all conditions honored in implementation)
 
 Extended by [ADR-006](./ADR-006-low-cost-data-plane-profiles.md)
-(proposed): optional object-storage/zero-Actions deployment profiles;
-no change to this ADR's defaults or contract.
+(IMPLEMENTED, epic #97): optional object-storage/zero-Actions
+deployment profiles; no change to this ADR's defaults or contract.
 
 ## Council Review
 

--- a/docs/adrs/ADR-006-low-cost-data-plane-profiles.md
+++ b/docs/adrs/ADR-006-low-cost-data-plane-profiles.md
@@ -2,9 +2,28 @@
 
 ## Status
 
-**APPROVED (council conditions incorporated)** — 2026-07-15. Extends
-ADR-005 (IMPLEMENTED); changes no default behavior. Everything here is
-an **optional deployment profile**. Implementation not yet scheduled.
+**IMPLEMENTED** — 2026-07-15 (epic #97: tickets #98–#104; approved with
+council conditions the same day, all five honored in implementation).
+Extends ADR-005 (IMPLEMENTED); changes no default behavior. Everything
+here is an **optional deployment profile**.
+
+Implementation map: `dataPlane` config (#98, PR #105) · R2 object store
++ §3 write-order writer (#99, PR #106) · Worker R2-writer mode +
+serving route + Workers-safe core split (#100, PR #107) · §5 compaction
+cron + lifecycle guardrails + doctor health (#101, PR #108) ·
+`migrate --to r2` / `--to git` (#102, PR #109) · Profile C e2e leg +
+condition-5 concurrency tests (#103, PR #110) · docs + this closeout
+(#104).
+
+Two corrections the implementation fed back into the design, both found
+by the condition-5 concurrency tests (PR #110):
+- the bounded read set must consume **batches before archives** — the
+  reverse order had a torn window against a concurrent compactor (a
+  freshly-archived day could vanish from one regenerate cycle); §3's
+  consistency argument now rests on compaction's delete-after-verify
+  ordering, which makes batch-first structurally lossless;
+- immutable batch creates retry once under a suffixed run id on a key
+  collision instead of failing the probe cycle.
 
 ## Council Review
 

--- a/docs/reference/DATA_PLANE.md
+++ b/docs/reference/DATA_PLANE.md
@@ -1,8 +1,10 @@
 # The status/v1 Data Plane (v1)
 
 Everything the status page renders comes from ONE schema-validated
-contract on a dedicated git branch (default `status-data`), written by
-`@stentorosaur/probe` and read by the plugin. Full rationale: ADR-005.
+contract — by default on a dedicated git branch (default
+`status-data`), written by `@stentorosaur/probe` and read by the
+plugin. Full rationale: ADR-005. The same contract can live in an R2
+bucket instead (ADR-006 Profile C, below).
 
 ```
 status/v1/
@@ -30,6 +32,7 @@ concurrent writers safe (regenerate-and-retry, ADR-005 §5).
 | `update-incidents` | sync GitHub issues → incidents/maintenance inputs + `raw/`, regenerate, push |
 | `regenerate` | §7 runbook: re-render every body from `raw/` with the current sanitizer |
 | `migrate` | one-time 0.x → v1 conversion (config + full history, zero loss) |
+| `migrate --to r2` / `--to git` | move the whole plane between git and an R2 bucket (verbatim copy, merge-by-content, `--dry-run` plans) |
 | `ingest --payload <file>` | receive a `repository_dispatch` probe payload (schema-gated) |
 
 All data-branch writers accept `--config <site>`, `--workdir <data
@@ -62,3 +65,40 @@ without a write credential in the Worker — ADR-005 §6), and quota math.
 Maintenance windows: issues with a `maintenance` label and a
 `start:`/`end:` frontmatter block (human-friendly dates like
 `@tomorrow 2am UTC` are parsed server-side).
+
+## Profile C: the same contract in an R2 bucket (ADR-006)
+
+Opting into `dataPlane: {kind: 'r2', …}` moves the plane to object
+storage: a Cloudflare Worker probes and writes directly through a
+bucket binding (zero GitHub Actions in the monitoring loop) and a
+serving route publishes `status/v1/*` with `Cache-Control`/ETag/CORS
+behind a **required custom domain**. Two storage-shape differences
+from git — the contract itself is identical:
+
+```
+status/v1/
+├── readings/<ts>-<runid>.json   # ONE immutable batch per probe run
+│                                # (R2 cannot append) — folded into
+│                                # archives/ by the daily compaction
+│                                # cron and then deleted
+└── compaction-state.json        # compaction health (lastRun,
+                                 # lastSuccess, quarantine count) —
+                                 # `stentorosaur doctor` reads it
+```
+
+Write-order consistency (ADR-006 §3): git's multi-file commit is
+replaced by a strict order — entity details → atom → **summary.json
+LAST, `If-Match`-guarded** — so a client never sees a summary newer
+than the inputs it references; the loser of a concurrent write
+re-reads everything and retries. Compaction (§5) is fenced (a day is
+only touched once closed plus 1 hour), verifies the archive byte-wise
+before deleting any batch, and converges on re-run after any crash.
+Both properties are enforced by concurrency tests (epic #97, ticket
+#103) and the r2 leg of the e2e matrix runs the full pipeline —
+Worker probe → compaction → serving route → built site — on every CI
+run.
+
+Setup runbook, budget math, and lifecycle guardrails:
+[templates/workflows/README](../../packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md)
+§"Profile C". Config reference:
+[CONFIGURATION.md](./CONFIGURATION.md) §`dataPlane`.

--- a/packages/docusaurus-plugin-stentorosaur/templates/worker/worker.mjs
+++ b/packages/docusaurus-plugin-stentorosaur/templates/worker/worker.mjs
@@ -1,7 +1,13 @@
 /**
- * Cloudflare Worker probe (ADR-005 §6) — checks the TARGETS and sends
- * readings to GitHub via repository_dispatch; the probe-dispatch-v1.yml
- * workflow validates and commits them. The Worker holds only a
- * dispatch-capable token and never writes to git.
+ * Cloudflare Worker probe. The mode is selected by the bindings:
+ *
+ * - Dispatch mode (ADR-005 §6, wrangler.toml): checks the TARGETS and
+ *   sends readings to GitHub via repository_dispatch; the
+ *   probe-dispatch-v1.yml workflow validates and commits them. The
+ *   Worker holds only a dispatch-capable token and never writes to git.
+ * - Profile C (ADR-006, wrangler-r2.toml): a STATUS_BUCKET R2 binding
+ *   is present — the Worker writes status/v1 to the bucket directly
+ *   (no GitHub credentials), serves it via `fetch`, and runs the daily
+ *   compaction pass on the COMPACTION_CRON trigger.
  */
 export {default} from '@stentorosaur/probe/worker';

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md
@@ -2,7 +2,18 @@
 
 This directory contains GitHub Actions workflow templates for monitoring your services and updating your status page.
 
-## Architecture Overview
+> ⚠️ **Start here if you're on plugin ≥ 1.0** (the current release): skip
+> straight to [status/v1 templates](#statusv1-templates-adr-005--plugin--022)
+> below. Everything between here and that section describes the
+> **pre-1.0 architecture** (`monitor-systems.yml`, `current.json`,
+> `.monitorrc.json`) — kept only for historical reference and for
+> anyone still mid-migration. It is superseded by ADR-005 (the
+> single `status/v1` contract) and, for zero-Actions deployments, by
+> ADR-006 Profile C below. New setups should use the `*-v1.yml`
+> templates and `stentorosaur.config.js`, not the workflows described
+> immediately below.
+
+## Architecture Overview (legacy, pre-1.0)
 
 The optimized architecture decouples **data collection** from **site builds**, enabling 5-minute monitoring at low cost:
 

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md
@@ -2,16 +2,16 @@
 
 This directory contains GitHub Actions workflow templates for monitoring your services and updating your status page.
 
-> ⚠️ **Start here if you're on plugin ≥ 1.0** (the current release): skip
-> straight to [status/v1 templates](#statusv1-templates-adr-005--plugin--022)
+> ⚠️ **Start here on plugin ≥ 0.22** (the current release is 1.0+):
+> skip straight to [status/v1 templates](#statusv1-templates-adr-005--plugin--022)
 > below. Everything between here and that section describes the
-> **pre-1.0 architecture** (`monitor-systems.yml`, `current.json`,
-> `.monitorrc.json`) — kept only for historical reference and for
-> anyone still mid-migration. It is superseded by ADR-005 (the
-> single `status/v1` contract) and, for zero-Actions deployments, by
-> ADR-006 Profile C below. New setups should use the `*-v1.yml`
-> templates and `stentorosaur.config.js`, not the workflows described
-> immediately below.
+> **legacy pre-ADR-005 architecture** (`monitor-systems.yml`,
+> `current.json`, `.monitorrc.json`) — kept only for historical
+> reference and for anyone still mid-migration from an older release.
+> It is superseded by ADR-005 (the single `status/v1` contract) and,
+> for zero-Actions deployments, by ADR-006 Profile C below. New setups
+> should use the `*-v1.yml` templates and `stentorosaur.config.js`,
+> not the workflows described immediately below.
 
 ## Architecture Overview (legacy, pre-1.0)
 

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/README.md
@@ -305,3 +305,40 @@ credentials at all) and a serving route publishes it with proper
 - Any R2 lifecycle expiry on `readings/` is a **backstop, never the
   mechanism**, and must be ≥ 3 days (see the comments in
   `wrangler-r2.toml`).
+
+#### Profile C setup, end to end
+
+1. **Bucket:** `wrangler r2 bucket create status`.
+2. **Worker:** copy `../worker/wrangler-r2.toml` + `worker.mjs` into a
+   Worker project, `npm i @stentorosaur/probe`, fill in `TARGETS` /
+   `SITE_TITLE` / `SITE_URL` (and optional `ENTITIES` display
+   metadata). Keep `COMPACTION_CRON` equal to the second `[triggers]`
+   cron. `wrangler deploy`.
+3. **Custom domain (REQUIRED):** attach a Cloudflare custom domain to
+   the Worker route (`[[routes]]` in the template) — e.g.
+   `status.example.com/status/v1/*`. Do NOT serve from workers.dev.
+4. **Site config:** in `stentorosaur.config.js` set
+   `dataPlane: {kind: 'r2', bucket, endpoint, publicBaseUrl}` (see
+   docs/reference/CONFIGURATION.md), and point the plugin's `dataUrl`
+   at `https://<custom-domain>/status/v1/summary.json`.
+5. **Incident sync (stays on Actions):** install
+   `status-update-v1.yml` as usual, then create an R2 API token —
+   Cloudflare dashboard → R2 → Manage API Tokens → **Object Read &
+   Write scoped to the one status bucket** — and add its credentials
+   as the `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` repo secrets
+   (the template forwards them; the CLI routes to the bucket because
+   of `dataPlane.kind`). Remove/skip `probe-v1.yml` and
+   `compact-data-branch-v1.yml` — the Worker probes and compacts.
+6. **Migrating existing history:** from a data-branch checkout,
+   `stentorosaur migrate --to r2 --config <site> --workdir <data
+   worktree>` copies archives + inputs + raw into the bucket
+   (verbatim; merge-by-content on divergence) and regenerates the
+   derived objects. `--dry-run` prints the plan first. `--to git`
+   is the inverse (bucket → branch commit) if you ever move back.
+7. **Optional lifecycle backstop:**
+   `wrangler r2 bucket lifecycle add status --prefix status/v1/readings/ --expire-days 3`
+   (≥ 3 days — shorter races the compaction fence). Archive expiry is
+   a pure retention choice.
+8. **Verify:** `npx stentorosaur doctor` — checks the summary at
+   `publicBaseUrl`, warns when the last compaction success is >48h
+   old or quarantined batches accumulate.

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/status-update-v1.yml
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/status-update-v1.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Update incidents on the data branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Only used when stentorosaur.config.js sets dataPlane
+          # {kind: 'r2'} (ADR-006 Profile C) — empty otherwise.
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
           # PINNED version (supply-chain: this workflow holds
           # contents:write). Bump deliberately when upgrading the plugin.


### PR DESCRIPTION
Closes #104

## What

The epic #97 closeout — documentation and ADR currency, no runtime code changes (one workflow template gains two pass-through env lines).

- **Root README:** deployment-profile chooser table (A: Actions+git / B: Worker dispatch+git / C: Worker+R2) with each profile's cost driver, the parameterized class-A budget formula, and the custom-domain mandate. Profile portability via `migrate --to` noted.
- **docs/reference/DATA_PLANE.md:** Profile C section — the two storage-shape differences (`readings/` immutable batches, `compaction-state.json`), the §3 write-order consistency model, the §5 compaction contract, and pointers to the runbook + config reference. `migrate --to r2|git` added to the CLI table.
- **templates/workflows/README.md:** numbered end-to-end Profile C setup runbook (bucket → Worker → custom domain → site config → R2 API token scopes for the Actions incident sync → history migration → lifecycle backstop → doctor), validated step-by-step against the actual template files.
- **status-update-v1.yml:** forwards `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` secrets (empty and harmless on git deployments) so runbook step 5 is true without editing the template.
- **worker.mjs template:** doc comment now covers both modes (dispatch vs Profile C by binding presence).
- **CHANGELOG:** `[Unreleased]` entry — Added (Profile C, e2e matrix, concurrency tests) and Fixed (the two defects the concurrency work caught in merged code).
- **ADR-006 Status → IMPLEMENTED** with the ticket→PR implementation map and the two implementation-fed design corrections (batch-first read order; collision-retried batch creates). **ADR-005 cross-reference** updated from '(proposed)' to '(IMPLEMENTED, epic #97)'.

## Acceptance criteria
- New-user Profile C standing-up from docs alone: the runbook references only files that exist (`wrangler-r2.toml` vars/triggers/routes checked line-by-line; `worker.mjs`; `status-update-v1.yml` env), the config block matches `dataPlaneSchema`, and every CLI invocation matches the shipped flags.
- ADR-006 status reflects reality; ADR-005 cross-reference updated.
- CHANGELOG entry present under Unreleased.

## Gates
Docs-only + template comment/env lines: `tsc --build` clean; probe 178 / core 73 / plugin 325 unchanged; workflow lint runs in CI (actionlint covers the template change).