### PR TITLE
fix: history-page long-range charts use the 90-day daily series (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Per-entity history page (`/status/history/<entity>`): the Uptime
+  Overview "Last 90 Days" bar chart (and the SLI/SLO + error-budget
+  charts) now fill their full window from the summary's 90-day daily
+  series instead of the short entity-detail `readings` window, which
+  only populated ~13-30 columns and padded the rest grey (#114). The
+  day-rollup → history merge that the `/status` heatmap already used is
+  now a shared `mergeDaysIntoHistory` helper used by both views;
+  Response Time keeps sub-daily readings. Degrades to readings-only if
+  the summary is unavailable.
 - `readAllReadings` (r2 plane) reads batches before archives — the
   reverse order could drop a freshly-compacted day from one regenerate
   cycle when racing the compaction cron.

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/StatusHistory.test.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/StatusHistory.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ *
+ * StatusHistory (issue #114): the per-entity history page must fill its
+ * long-range Uptime Overview from the summary's 90-day daily series, not
+ * only the short entity-detail readings window. Reproduces the bug at
+ * the DOM level: with the fix the 90d view has ~90 populated day-columns
+ * instead of the ~2 the readings window alone would produce.
+ */
+
+import React from 'react';
+import {render, screen, waitFor, within} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import StatusHistory from '../src/theme/StatusHistory';
+
+const NEWEST_DATE = '2026-07-15';
+
+function entityDetail() {
+  const t = Date.parse(`${NEWEST_DATE}T12:00:00.000Z`);
+  return {
+    schemaVersion: 1,
+    generatedAt: `${NEWEST_DATE}T12:00:00.000Z`,
+    name: 'alpha',
+    readings: [
+      {t: t - 86_400_000, svc: 'alpha', state: 'up', code: 200, lat: 40},
+      {t, svc: 'alpha', state: 'up', code: 200, lat: 41},
+    ],
+  };
+}
+
+/** Summary with a full 90-day series for 'alpha' (compact day tuples). */
+function summaryWith90Days() {
+  const days = Array.from({length: 90}, () => [100, 40, 'u']);
+  return {
+    schemaVersion: 1,
+    generatedAt: `${NEWEST_DATE}T12:00:00.000Z`,
+    generatedBy: 'test',
+    entities: [
+      {
+        name: 'alpha',
+        type: 'system',
+        status: 'up',
+        uptime: {d1: 100, d7: 100, d90: 100},
+        responseTimeMs: {d1: 40},
+        daysEnd: NEWEST_DATE,
+        days,
+      },
+    ],
+    incidents: {open: [], recent: []},
+    maintenance: {upcoming: [], inProgress: []},
+  };
+}
+
+function mockFetch(summaryResponder: (url: string) => {ok: boolean; status?: number; body?: unknown}) {
+  global.fetch = jest.fn(async (url: string) => {
+    if (url.endsWith('/entities/alpha.json')) {
+      return {ok: true, status: 200, json: async () => entityDetail()} as any;
+    }
+    const r = summaryResponder(url);
+    return {ok: r.ok, status: r.status ?? (r.ok ? 200 : 404), statusText: 'x', json: async () => r.body} as any;
+  }) as unknown as typeof fetch;
+}
+
+/** How many 90d uptime bars carry real data (title !== "... no data"). */
+function populatedBarCount(): number {
+  return screen
+    .getAllByTestId('uptime-bar')
+    .filter(bar => !(bar.querySelector('title')?.textContent ?? '').includes('no data')).length;
+}
+
+beforeEach(() => {
+  window.history.pushState({}, '', '/status/history/alpha');
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('StatusHistory (issue #114)', () => {
+  it('fills the 90d Uptime Overview from the summary daily series', async () => {
+    mockFetch(url => (url.endsWith('/summary.json') ? {ok: true, body: summaryWith90Days()} : {ok: false}));
+    render(<StatusHistory />);
+
+    await waitFor(() => expect(screen.getByText(/alpha/i)).toBeInTheDocument());
+    // The default Uptime Overview period is 90d; with the daily series
+    // merged in, the overwhelming majority of the 90 columns have data
+    // (readings alone would populate ~2).
+    await waitFor(() => expect(populatedBarCount()).toBeGreaterThan(80));
+    expect(screen.getByText(/spans up to 90 days from the daily summary/i)).toBeInTheDocument();
+  });
+
+  it('degrades gracefully when the summary is unavailable (readings-only, no error)', async () => {
+    mockFetch(url => (url.endsWith('/summary.json') ? {ok: false, status: 404} : {ok: false}));
+    render(<StatusHistory />);
+
+    await waitFor(() => expect(screen.getByText(/alpha/i)).toBeInTheDocument());
+    // No daily series → the page still renders (no error state) and does
+    // NOT claim a 90-day span.
+    expect(screen.queryByText(/Error Loading Data/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/from the daily summary/i)).not.toBeInTheDocument();
+    // Only the readings window populates the 90d view.
+    expect(populatedBarCount()).toBeLessThan(10);
+  });
+});

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/mergeDays.test.ts
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/mergeDays.test.ts
@@ -1,0 +1,90 @@
+/**
+ * mergeDaysIntoHistory (issue #114): the shared day-rollup → history
+ * merge that lets long-range charts fill 90 days from the daily series
+ * instead of the short readings window.
+ */
+
+import {mergeDaysIntoHistory} from '../src/theme/StatusPage/mergeDays';
+import type {DayRollup} from '@stentorosaur/core';
+import type {StatusCheckHistory} from '../src/types';
+
+const reading = (iso: string, responseTime = 40): StatusCheckHistory => ({
+  timestamp: iso,
+  status: 'up',
+  code: 200,
+  responseTime,
+});
+
+const day = (date: string, over: Partial<DayRollup> = {}): DayRollup => ({
+  date,
+  uptime: 100,
+  avgMs: 30,
+  worst: 'up',
+  ...over,
+});
+
+describe('mergeDaysIntoHistory', () => {
+  it('fills older days from the rollups while keeping recent readings (the #114 fix)', () => {
+    // Two days of sub-daily readings; rollups span 90 days.
+    const history = [
+      reading('2026-07-14T06:00:00.000Z'),
+      reading('2026-07-14T18:00:00.000Z'),
+      reading('2026-07-15T06:00:00.000Z'),
+    ];
+    const days: DayRollup[] = [];
+    const start = Date.parse('2026-04-17T00:00:00Z');
+    for (let i = 0; i < 90; i++) {
+      days.push(day(new Date(start + i * 86_400_000).toISOString().split('T')[0]));
+    }
+
+    const merged = mergeDaysIntoHistory(history, days, 90);
+
+    // Every one of the 90 days is represented (older via rollups, the
+    // two recent days via their readings) — no empty columns.
+    const dates = new Set(merged.map(h => h.timestamp.split('T')[0]));
+    expect(dates.size).toBe(90);
+    // Recent days keep their high-resolution readings (3 checks across
+    // 2 recent days) rather than being replaced by a single rollup.
+    expect(merged.filter(h => h.timestamp.startsWith('2026-07-14')).length).toBe(2);
+  });
+
+  it('does not duplicate a day already covered by readings (existing wins)', () => {
+    const history = [reading('2026-07-15T06:00:00.000Z', 11)];
+    const days = [day('2026-07-15', {avgMs: 999})]; // same day, different value
+    const merged = mergeDaysIntoHistory(history, days, 90);
+    const jul15 = merged.filter(h => h.timestamp.startsWith('2026-07-15'));
+    expect(jul15).toHaveLength(1);
+    expect(jul15[0].responseTime).toBe(11); // the reading, not the rollup
+  });
+
+  it('maps rollup fields: down day → 500, avgMs → responseTime, worst → status', () => {
+    const merged = mergeDaysIntoHistory([], [day('2026-05-01', {uptime: 0, worst: 'down', avgMs: null})], 90);
+    expect(merged[0]).toMatchObject({status: 'down', code: 500, responseTime: 0});
+  });
+
+  it('returns history unchanged when there are no rollups', () => {
+    const history = [reading('2026-07-15T06:00:00.000Z')];
+    expect(mergeDaysIntoHistory(history, [], 90)).toBe(history);
+  });
+
+  it('clamps to the most recent daysToShow rollups', () => {
+    const days = Array.from({length: 90}, (_, i) =>
+      day(new Date(Date.parse('2026-04-17T00:00:00Z') + i * 86_400_000).toISOString().split('T')[0])
+    );
+    const merged = mergeDaysIntoHistory([], days, 30);
+    expect(merged).toHaveLength(30);
+    // Newest-first, and only the last 30 calendar days are present.
+    expect(merged[0].timestamp.split('T')[0]).toBe(days[89].date);
+    expect(merged[29].timestamp.split('T')[0]).toBe(days[60].date);
+  });
+
+  it('sorts newest-first', () => {
+    const merged = mergeDaysIntoHistory(
+      [reading('2026-07-15T06:00:00.000Z')],
+      [day('2026-05-01'), day('2026-06-01')],
+      90
+    );
+    const times = merged.map(h => new Date(h.timestamp).getTime());
+    expect(times).toEqual([...times].sort((a, b) => b - a));
+  });
+});

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/StatusHistory/index.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/StatusHistory/index.tsx
@@ -5,14 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import Layout from '@theme/Layout';
 import ResponseTimeChart from '../ResponseTimeChart';
 import UptimeChart from '../UptimeChart';
 import SLIChart from '../SLIChart';
 import type { SystemStatusFile } from '../../types';
-import { parseEntityDetail } from '@stentorosaur/core';
-import { detailToSystemFile, deriveV1BaseUrl } from '../StatusPage';
+import { decodeDayRollups, parseEntityDetail, parseSummary } from '@stentorosaur/core';
+import { detailToSystemFile, deriveV1BaseUrl, entitySlug } from '../StatusPage';
+import { mergeDaysIntoHistory } from '../StatusPage/mergeDays';
 import styles from './styles.module.css';
 
 export interface Props {
@@ -53,7 +54,27 @@ export default function StatusHistory({
           throw new Error(`Failed to load data: ${response.statusText}`);
         }
         const detail = parseEntityDetail(await response.json());
-        setSystemData(detailToSystemFile(detail));
+        const system = detailToSystemFile(detail);
+
+        // Also pull the 90-day daily series from the summary so the
+        // long-range uptime/SLI charts fill their window (issue #114) —
+        // the entity-detail readings are only a short rolling window.
+        // Optional: if the summary is unavailable the page still renders
+        // from readings (short ranges), unchanged.
+        try {
+          const summaryResponse = await fetch(`${v1Base}/summary.json`);
+          if (summaryResponse.ok) {
+            const summary = parseSummary(await summaryResponse.json());
+            const entity = summary.entities.find(e => entitySlug(e.name) === systemName);
+            if (entity) {
+              system.days = decodeDayRollups(entity);
+            }
+          }
+        } catch {
+          // Summary is an enhancement, not a requirement — keep the
+          // readings-only view rather than failing the page.
+        }
+        setSystemData(system);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load system data');
       } finally {
@@ -63,6 +84,14 @@ export default function StatusHistory({
 
     loadSystemData();
   }, [dataPath, config]);
+
+  // Merge the 90-day daily series into the history the long-range
+  // uptime/SLI charts read (issue #114). No daily series (summary
+  // missing) → the raw readings pass through unchanged.
+  const chartHistory = useMemo(
+    () => (systemData ? mergeDaysIntoHistory(systemData.history, systemData.days ?? [], 90) : []),
+    [systemData]
+  );
 
   if (loading) {
     return (
@@ -191,7 +220,7 @@ export default function StatusHistory({
           </div>
           <UptimeChart
             name={systemData.name}
-            history={systemData.history}
+            history={chartHistory}
             chartType={chartType}
             showPeriodSelector={true}
           />
@@ -201,7 +230,7 @@ export default function StatusHistory({
           <h2>SLI/SLO Compliance</h2>
           <SLIChart
             name={systemData.name}
-            history={systemData.history}
+            history={chartHistory}
             showPeriodSelector={true}
             sloTarget={systemData.sloTarget || 99.9}
           />
@@ -211,7 +240,7 @@ export default function StatusHistory({
           <h2>Error Budget Tracking</h2>
           <SLIChart
             name={systemData.name}
-            history={systemData.history}
+            history={chartHistory}
             showPeriodSelector={true}
             showErrorBudget={true}
             sloTarget={systemData.sloTarget || 99.9}
@@ -221,8 +250,11 @@ export default function StatusHistory({
         <section className={styles.dataSection}>
           <h2>Historical Data</h2>
           <p className={styles.dataInfo}>
-            Showing {systemData.history.length} data points collected over the past 30 days.
-            Data is updated every 5 minutes.
+            Showing {systemData.history.length} recent checks
+            {systemData.days?.length
+              ? `; uptime and SLI history spans up to ${Math.min(systemData.days.length, 90)} days from the daily summary`
+              : ''}
+            . Data is updated every 5 minutes.
           </p>
         </section>
       </main>

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/StatusItem/index.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/StatusItem/index.tsx
@@ -7,6 +7,7 @@
 
 import React, { useMemo } from 'react';
 import type {StatusItem as StatusItemType, StatusIncident, ScheduledMaintenance, StatusCheckHistory} from '../../types';
+import {mergeDaysIntoHistory} from '../StatusPage/mergeDays';
 import MiniHeatmap from './MiniHeatmap';
 import styles from './styles.module.css';
 
@@ -66,40 +67,13 @@ export default function StatusItem({
   const daysToShow = heatmapDays ?? (item.days?.length ? 90 : 14);
 
   // v1 (ADR-005): day rollups arrive ON the item — no runtime fetch.
-  const enhancedHistory = useMemo((): StatusCheckHistory[] => {
-    const existingHistory = item.history || [];
-    const days = (item.days ?? []).slice(-daysToShow);
-    if (days.length === 0) {
-      return existingHistory;
-    }
-
-    // Each day becomes a single representative "check".
-    const summaryAsHistory: StatusCheckHistory[] = days.map(day => ({
-      timestamp: `${day.date}T12:00:00Z`,
-      status: day.worst,
-      code: day.uptime > 0 ? 200 : 500,
-      responseTime: day.avgMs || 0,
-    }));
-
-    // Merge: prefer existing history for recent days, use summary for older days
-    const existingDates = new Set(
-      existingHistory.map(h => h.timestamp.split('T')[0])
-    );
-
-    // Add summary entries for dates not in existing history
-    const combined = [...existingHistory];
-    for (const entry of summaryAsHistory) {
-      const dateKey = entry.timestamp.split('T')[0];
-      if (!existingDates.has(dateKey)) {
-        combined.push(entry);
-      }
-    }
-
-    // Sort by timestamp descending (most recent first)
-    return combined.sort(
-      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-    );
-  }, [item.history, item.days, daysToShow]);
+  // Shared with the history-page charts (issue #114): recent readings
+  // win, older days are filled from the daily rollups.
+  const enhancedHistory = useMemo(
+    (): StatusCheckHistory[] =>
+      mergeDaysIntoHistory(item.history || [], item.days ?? [], daysToShow),
+    [item.history, item.days, daysToShow]
+  );
 
   return (
     <div 

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/mergeDays.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/mergeDays.ts
@@ -1,0 +1,58 @@
+/**
+ * Merge the 90-day daily rollup series into a per-entity check history
+ * so long-range charts (Uptime Overview 30d/90d, SLI/SLO, error budget)
+ * can fill their full window from the daily aggregate — issue #114.
+ *
+ * The entity-detail `readings` file is only a short rolling window
+ * (~13-30 days), so a 90-day view built from it alone shows mostly
+ * empty columns. The 90-day daily series lives in `summary.json`
+ * (per-entity `days` rollups) and already backs the `/status` heatmap
+ * (StatusItem). This is the single shared merge both views use:
+ * high-resolution readings win for recent days, daily rollups fill the
+ * older days.
+ */
+
+import type {DayRollup} from '@stentorosaur/core';
+import type {StatusCheckHistory} from '../../types';
+
+/**
+ * Combine `existingHistory` (sub-daily readings) with `days` (daily
+ * rollups). Recent days keep their high-resolution readings; any day
+ * NOT already present in `existingHistory` is filled with one
+ * representative daily check. Result is sorted newest-first (what the
+ * charts and heatmap expect). `daysToShow` clamps the rollups to the
+ * most recent N days.
+ */
+export function mergeDaysIntoHistory(
+  existingHistory: StatusCheckHistory[],
+  days: DayRollup[],
+  daysToShow: number
+): StatusCheckHistory[] {
+  const recent = days.slice(-daysToShow);
+  if (recent.length === 0) {
+    return existingHistory;
+  }
+
+  // Each rollup day becomes a single representative "check" at midday.
+  const summaryAsHistory: StatusCheckHistory[] = recent.map(day => ({
+    timestamp: `${day.date}T12:00:00Z`,
+    status: day.worst,
+    code: day.uptime > 0 ? 200 : 500,
+    responseTime: day.avgMs || 0,
+  }));
+
+  // Prefer existing (high-resolution) history for days it already
+  // covers; only add rollup days that are missing.
+  const existingDates = new Set(existingHistory.map(h => h.timestamp.split('T')[0]));
+  const combined = [...existingHistory];
+  for (const entry of summaryAsHistory) {
+    const dateKey = entry.timestamp.split('T')[0];
+    if (!existingDates.has(dateKey)) {
+      combined.push(entry);
+    }
+  }
+
+  return combined.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+}

--- a/packages/docusaurus-plugin-stentorosaur/src/types.ts
+++ b/packages/docusaurus-plugin-stentorosaur/src/types.ts
@@ -30,6 +30,10 @@ export interface SystemStatusFile {
   uptimeMonth?: string;
   uptime?: string;
   sloTarget?: number;
+  /** 90-day daily rollups from the summary (issue #114) — lets the
+   * long-range charts fill their window from the daily aggregate
+   * rather than the short entity-detail readings window. */
+  days?: DayRollup[];
 }
 
 export interface StatusItem {


### PR DESCRIPTION
Closes #114

## Problem

On `/status/history/<entity>`, the **Uptime Overview → Bar Chart → Last 90 Days** view rendered only ~13–30 real day-columns and padded the rest grey, even with 90+ days of history — while the `/status` heatmap for the same entity correctly showed a full 90 days. The two views read different sources: the detail page fed **raw entity-detail `readings`** (a short rolling window) to every chart, while the heatmap uses the **summary's 90-day daily series**.

## Fix (the issue's option 1)

- **Extract the day-rollup → history merge** — previously inlined in `StatusItem` for the heatmap — into a shared, pure, unit-tested `mergeDaysIntoHistory` (`src/theme/StatusPage/mergeDays.ts`): high-resolution readings win for recent days, daily rollups fill the older days, sorted newest-first. `StatusItem` now calls it (behaviour-preserving; its existing tests still pass).
- **`StatusHistory`** now also fetches `summary.json`, finds the entity by slug, `decodeDayRollups` its 90-day tuples, and feeds the **merged** history to `UptimeChart` and the SLI/SLO + error-budget `SLIChart`s. **Response Time keeps raw readings** (a rollup's `avgMs` can be `null` → would plot 0 ms). The summary is optional: if it's unavailable the page renders readings-only, unchanged (no new failure mode). Footer text corrected (was hardcoded "past 30 days").
- `SystemStatusFile` gains `days?: DayRollup[]`.

No data-plane or probe changes — the 90-day series already exists in `summary.json`; this is purely wiring the detail page to it.

## Tests (8 new)

- `mergeDaysIntoHistory` unit tests: fills 90 days while keeping recent readings; existing day not duplicated (reading wins); field mapping (down→500, `avgMs`→responseTime, `worst`→status); no-rollups passthrough; clamp to `daysToShow`; newest-first sort.
- `StatusHistory` jsdom test **reproduces the bug at the DOM level**: with a 90-day summary the 90d Uptime Overview has **>80 of 90 columns populated** (readings alone → `<10`), plus the graceful-degrade case (summary 404 → renders readings-only, no error, no 90-day claim).

## Gates

- core 76 / plugin 336 (8 new); `tsc --build` clean; **e2e git 16/16 and r2 16/16** (theme components changed).

Related: #93 (chart display fast-follows).