### PR TITLE
chore(release): v1.1.0 (plugin 1.1.0 · core 0.2.0 · probe 0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-16
+
+Accompanied by `@stentorosaur/core` 0.2.0 and `@stentorosaur/probe`
+0.2.0 (Profile C data plane, `migrate --to`, compaction, and the
+`init` seed all live in the probe/core packages). The v1 workflow
+templates now pin `@stentorosaur/probe@0.2.0`.
+
 ### Added
 
 - **First-run bootstrap**: `stentorosaur init` now seeds an empty-but-valid

--- a/package-lock.json
+++ b/package-lock.json
@@ -24433,7 +24433,7 @@
     },
     "packages/core": {
       "name": "@stentorosaur/core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chrono-node": "^2.9.0",
@@ -24522,13 +24522,13 @@
     },
     "packages/docusaurus-plugin-stentorosaur": {
       "name": "@amiable-dev/docusaurus-plugin-stentorosaur",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "^3.0.0",
         "@docusaurus/types": "^3.0.0",
         "@docusaurus/utils": "^3.0.0",
-        "@stentorosaur/core": "^0.1.0",
+        "@stentorosaur/core": "^0.2.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
       },
@@ -24554,10 +24554,10 @@
     },
     "packages/probe": {
       "name": "@stentorosaur/probe",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@stentorosaur/core": "^0.1.0",
+        "@stentorosaur/core": "^0.2.0",
         "aws4fetch": "^1.0.20",
         "jiti": "^2.4.0",
         "zod": "^4.1.12"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stentorosaur/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pure schemas and aggregation logic for Stentorosaur status monitoring (ADR-005). No I/O.",
   "license": "MIT",
   "author": "Amiable Development <dev@amiable.dev>",

--- a/packages/docusaurus-plugin-stentorosaur/package.json
+++ b/packages/docusaurus-plugin-stentorosaur/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amiable-dev/docusaurus-plugin-stentorosaur",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A Docusaurus plugin for displaying status monitoring dashboard powered by GitHub Issues and Actions, similar to Upptime",
   "main": "lib/index.js",
   "types": "src/plugin-status.d.ts",
@@ -37,7 +37,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@stentorosaur/core": "^0.1.0",
+    "@stentorosaur/core": "^0.2.0",
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/types": "^3.0.0",
     "@docusaurus/utils": "^3.0.0",

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/probe-dispatch-v1.yml
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/probe-dispatch-v1.yml
@@ -47,5 +47,5 @@ jobs:
         run: |
           # PINNED version (supply-chain: this workflow holds
           # contents:write). Bump deliberately when upgrading the plugin.
-          npx -y -p @stentorosaur/probe@0.1.1 stentorosaur ingest \
+          npx -y -p @stentorosaur/probe@0.2.0 stentorosaur ingest \
             --payload /tmp/dispatch-payload.json

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/probe-v1.yml
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/probe-v1.yml
@@ -42,5 +42,5 @@ jobs:
         run: |
           # PINNED version (supply-chain: this workflow holds
           # contents:write). Bump deliberately when upgrading the plugin.
-          npx -y -p @stentorosaur/probe@0.1.1 \
+          npx -y -p @stentorosaur/probe@0.2.0 \
             stentorosaur probe --config . --workdir . --branch status-data

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/status-update-v1.yml
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/status-update-v1.yml
@@ -46,5 +46,5 @@ jobs:
         run: |
           # PINNED version (supply-chain: this workflow holds
           # contents:write). Bump deliberately when upgrading the plugin.
-          npx -y -p @stentorosaur/probe@0.1.1 \
+          npx -y -p @stentorosaur/probe@0.2.0 \
             stentorosaur update-incidents --config . --workdir . --branch status-data

--- a/packages/probe/package.json
+++ b/packages/probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stentorosaur/probe",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Monitoring engine and I/O for Stentorosaur (ADR-005 §1). All fetching (HTTP checks, GitHub API, git writes) lives here; transforms live in @stentorosaur/core.",
   "license": "MIT",
   "author": "Amiable Development <dev@amiable.dev>",
@@ -39,7 +39,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stentorosaur/core": "^0.1.0",
+    "@stentorosaur/core": "^0.2.0",
     "jiti": "^2.4.0",
     "aws4fetch": "^1.0.20",
     "zod": "^4.1.12"


### PR DESCRIPTION
Release prep for **v1.1.0**. Publishes on GitHub Release (publish.yml).

## Versions
- `@amiable-dev/docusaurus-plugin-stentorosaur` 1.0.1 → **1.1.0**
- `@stentorosaur/core` 0.1.0 → **0.2.0**
- `@stentorosaur/probe` 0.1.1 → **0.2.0**

## What ships
- **Profile C** (ADR-006 R2 data plane, epic #97): Worker + R2, `migrate --to r2|git`, compaction, serving route.
- **#113** first-run bootstrap: `init` seeds an empty summary + `allowMissingData` opt-in.
- **#114** history-page charts fill 90 days from the daily series.

## Load-bearing beyond version numbers
- **Interdependency ranges**: `probe` and `plugin` now require `@stentorosaur/core: ^0.2.0`. `^0.1.0` (caret on 0.x) would resolve a stale core on a fresh npm install — CI can't catch this (workspaces link locally), so it's set by reasoning.
- **Template pins**: `probe-v1.yml` / `status-update-v1.yml` / `probe-dispatch-v1.yml` now pin `@stentorosaur/probe@0.2.0` (published before the plugin in the same release run), so the Profile C runbook installs the R2-capable probe.
- `package-lock.json` synced.

## Validation (mirrors publish.yml)
- `npm run build --workspaces` clean; `npm test --workspaces`: core 76 / probe 180 / plugin 336.
- `npm pack --dry-run` confirms `templates/worker/wrangler-r2.toml` + workflow templates ship.

Note: publish.yml runs `npm test` (parallel); the known flaky `use-status-summary.test.tsx` (#116) could intermittently fail that step — publish is idempotent (skip-if-published), so re-run the workflow if it flakes.

After merge: tag `v1.1.0` + create the GitHub Release → publish.yml publishes core → probe → plugin.