### PR TITLE
fix: rebuild git-plane entity-detail window + modal long-range charts (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Drill-down charts (Performance Metrics modal + per-entity history page)
+  no longer render only a single "Data Points: 1" reading (#119, follow-up
+  to #114). Root cause: on the **git data plane** the probe overwrites each
+  entity detail with only its latest batch, and `regenerateDerived` never
+  rebuilt it — so the drill-down window collapsed to one point after the
+  first probe cycle (the R2 plane already rebuilt it every cycle). Now the
+  git-plane `regenerateDerived` **rebuilds each entity detail from the
+  recent 14-day archive window every cycle**, symmetric with the R2 plane
+  and self-healing on the next probe. The archives are the append-only
+  source of truth and are never modified — **no monitoring data is lost**.
+  Response Time and short-range Uptime/SLI now render real history in both
+  the modal and the history page.
+- The Performance Metrics modal's long-range Uptime/SLI now fill from the
+  90-day daily series (via the shared `mergeDaysIntoHistory`), matching the
+  history page. Response Time stays on per-check readings (daily rollups
+  carry no latency).
+
 ## [1.1.0] - 2026-07-16
 
 Accompanied by `@stentorosaur/core` 0.2.0 and `@stentorosaur/probe`

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/PerformanceMetrics.test.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/PerformanceMetrics.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ *
+ * PerformanceMetrics modal (#119): its Uptime/SLI charts must fill from
+ * the 90-day daily series when the systemFile carries `days`, instead of
+ * the 1-point readings buffer. Response Time stays on raw readings.
+ */
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PerformanceMetrics from '../src/theme/PerformanceMetrics';
+import type {SystemStatusFile} from '../src/types';
+import type {DayRollup} from '@stentorosaur/core';
+
+const NEWEST = '2026-07-16';
+
+function systemFile(withDays: boolean): SystemStatusFile {
+  const days: DayRollup[] = Array.from({length: 90}, (_, i) => ({
+    date: new Date(Date.parse(`${NEWEST}T00:00:00Z`) - (89 - i) * 86_400_000).toISOString().split('T')[0],
+    uptime: 100,
+    avgMs: 40,
+    worst: 'up' as const,
+  }));
+  return {
+    name: 'api',
+    url: 'https://api.test',
+    lastChecked: `${NEWEST}T12:00:00.000Z`,
+    currentStatus: 'up',
+    // 1-point readings buffer (the bug shape).
+    history: [{timestamp: `${NEWEST}T12:00:00.000Z`, status: 'up', code: 200, responseTime: 41}],
+    ...(withDays ? {days} : {}),
+  };
+}
+
+/** Populated (non-"no data") uptime bars in the current view. */
+function populatedBars(): number {
+  return screen
+    .getAllByTestId('uptime-bar')
+    .filter(b => !(b.querySelector('title')?.textContent ?? '').includes('no data')).length;
+}
+
+describe('PerformanceMetrics (#119)', () => {
+  it('fills the modal Uptime chart from the daily series when days are present', () => {
+    render(<PerformanceMetrics systemFile={systemFile(true)} isVisible />);
+    // Default period is 7d → 7 daily blocks, all filled from the rollups
+    // (the 1-point readings buffer alone would fill just today).
+    expect(populatedBars()).toBeGreaterThanOrEqual(6);
+  });
+
+  it('without a daily series, the modal Uptime shows only the readings buffer', () => {
+    render(<PerformanceMetrics systemFile={systemFile(false)} isVisible />);
+    expect(populatedBars()).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/PerformanceMetrics/index.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/PerformanceMetrics/index.tsx
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import ResponseTimeChart from '../ResponseTimeChart';
 import UptimeChart from '../UptimeChart';
 import SLIChart from '../SLIChart';
+import { mergeDaysIntoHistory } from '../StatusPage/mergeDays';
 import type { SystemStatusFile, StatusIncident, ScheduledMaintenance } from '../../types';
 import styles from './styles.module.css';
 
@@ -41,6 +42,15 @@ export default function PerformanceMetrics({
   const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>('7d');
   const [fullscreenChart, setFullscreenChart] = useState<ChartType | null>(null);
   const [uptimeChartType, setUptimeChartType] = useState<'bar' | 'heatmap'>('bar');
+
+  // Long-range Uptime/SLI fill from the 90-day daily series (#114/#119),
+  // same as the history page. Response Time keeps the raw per-check
+  // readings (daily rollups carry no latency). Empty days → history
+  // passes through unchanged.
+  const uptimeHistory = useMemo(
+    () => mergeDaysIntoHistory(systemFile.history, systemFile.days ?? [], 90),
+    [systemFile]
+  );
 
   const handleChartClick = useCallback((chartType: ChartType) => {
     setFullscreenChart(chartType);
@@ -132,7 +142,7 @@ export default function PerformanceMetrics({
             </div>
             <UptimeChart
               name={systemFile.name}
-              history={systemFile.history}
+              history={uptimeHistory}
               incidents={incidents}
               maintenance={maintenance}
               chartType={uptimeChartType}
@@ -148,7 +158,7 @@ export default function PerformanceMetrics({
             </div>
             <SLIChart
               name={systemFile.name}
-              history={systemFile.history}
+              history={uptimeHistory}
               period={selectedPeriod}
               height={280}
               showPeriodSelector={false}
@@ -163,7 +173,7 @@ export default function PerformanceMetrics({
             </div>
             <SLIChart
               name={systemFile.name}
-              history={systemFile.history}
+              history={uptimeHistory}
               period={selectedPeriod}
               height={280}
               showPeriodSelector={false}
@@ -216,7 +226,7 @@ export default function PerformanceMetrics({
                   <h2>Uptime - {systemFile.name}</h2>
                   <UptimeChart
                     name={systemFile.name}
-                    history={systemFile.history}
+                    history={uptimeHistory}
                     incidents={incidents}
                     maintenance={maintenance}
                     chartType={uptimeChartType}
@@ -230,7 +240,7 @@ export default function PerformanceMetrics({
                   <h2>SLI/SLO Compliance - {systemFile.name}</h2>
                   <SLIChart
                     name={systemFile.name}
-                    history={systemFile.history}
+                    history={uptimeHistory}
                     period={selectedPeriod}
                     height={600}
                     showPeriodSelector={false}
@@ -243,7 +253,7 @@ export default function PerformanceMetrics({
                   <h2>Error Budget - {systemFile.name}</h2>
                   <SLIChart
                     name={systemFile.name}
-                    history={systemFile.history}
+                    history={uptimeHistory}
                     period={selectedPeriod}
                     height={600}
                     showPeriodSelector={false}

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
@@ -131,7 +131,13 @@ function StatusPageInner({
       });
       if (!response.ok) return;
       const detail = parseEntityDetail(JSON.parse(await response.text()));
-      setSystemFiles(prev => new Map(prev).set(name, detailToSystemFile(detail)));
+      const file = detailToSystemFile(detail);
+      // Carry the entity's 90-day daily rollups (already on the adapted
+      // item) so the modal's long-range Uptime/SLI fill from them, like
+      // the history page (#119).
+      const days = items.find(i => i.name === name)?.days;
+      if (days?.length) file.days = days;
+      setSystemFiles(prev => new Map(prev).set(name, file));
     } catch {
       // Detail data is enhancement-only; the card still renders.
     }

--- a/packages/probe/__tests__/regenerate-entity-detail.test.ts
+++ b/packages/probe/__tests__/regenerate-entity-detail.test.ts
@@ -1,0 +1,109 @@
+/**
+ * git-plane entity-detail window rebuild (#119).
+ *
+ * The probe's writeReadings overwrites each entity detail with only its
+ * latest batch (1 point). regenerateDerived must rebuild the detail from
+ * the recent archive window so drill-down charts have real history — and
+ * must do so WITHOUT touching the archives, which are the append-only
+ * source of truth (the "no monitoring data loss" constraint).
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {parseEntityDetail} from '@stentorosaur/core';
+import type {CompactReading} from '@stentorosaur/core';
+import {appendArchive, writeEntityDetail} from '../src/files';
+import {regenerateDerived} from '../src/regenerate';
+
+const NOW = Date.parse('2026-07-16T12:00:00.000Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'regen-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, {recursive: true, force: true});
+});
+
+const reading = (svc: string, t: number, lat = 40): CompactReading => ({
+  t,
+  svc,
+  state: 'up',
+  code: 200,
+  lat,
+});
+
+/** Seed `days` days of archive readings (one/day) for a service. */
+function seedArchive(svc: string, days: number): CompactReading[] {
+  const seeded: CompactReading[] = [];
+  for (let d = days; d >= 1; d--) {
+    const r = reading(svc, NOW - d * DAY, 30 + d);
+    appendArchive(tmp, r);
+    seeded.push(r);
+  }
+  return seeded;
+}
+
+function regen() {
+  regenerateDerived(tmp, {
+    generatedAt: new Date(NOW).toISOString(),
+    generatedBy: 'test',
+    entities: [{name: 'api', type: 'system'}],
+    siteTitle: 'T',
+    siteUrl: 'https://t.example.com',
+  });
+}
+
+function readDetail(svc: string) {
+  const file = path.join(tmp, 'status', 'v1', 'entities', `${svc}.json`);
+  return parseEntityDetail(JSON.parse(fs.readFileSync(file, 'utf8')));
+}
+
+describe('regenerateDerived rebuilds the entity-detail window (#119)', () => {
+  it('restores the 14-day window from archives even when the detail was collapsed to 1 point', () => {
+    seedArchive('api', 20); // 20 days in the archives
+    // Simulate the probe's collapse: detail holds only the latest batch.
+    writeEntityDetail(tmp, 'api', [reading('api', NOW, 99)], new Date(NOW).toISOString());
+    expect(readDetail('api').readings).toHaveLength(1);
+
+    regen();
+
+    const rebuilt = readDetail('api').readings;
+    // Only the last 14 days are in the detail window (not all 20, not 1).
+    expect(rebuilt.length).toBe(14);
+    const oldest = Math.min(...rebuilt.map(r => r.t));
+    expect(oldest).toBeGreaterThanOrEqual(NOW - 14 * DAY);
+    // Sorted oldest→newest.
+    expect(rebuilt.map(r => r.t)).toEqual([...rebuilt.map(r => r.t)].sort((a, b) => a - b));
+  });
+
+  it('does NOT lose monitoring data: the archives are byte-identical after regenerate', () => {
+    seedArchive('api', 20);
+    const archivesDir = path.join(tmp, 'status', 'v1', 'archives');
+    const snapshot = (): Record<string, string> => {
+      const out: Record<string, string> = {};
+      const walk = (dir: string) => {
+        for (const e of fs.readdirSync(dir, {withFileTypes: true})) {
+          const full = path.join(dir, e.name);
+          if (e.isDirectory()) walk(full);
+          else out[path.relative(archivesDir, full)] = fs.readFileSync(full, 'utf8');
+        }
+      };
+      walk(archivesDir);
+      return out;
+    };
+    const before = snapshot();
+    regen();
+    expect(snapshot()).toEqual(before); // archives untouched
+  });
+
+  it('leaves an entity with no readings in the window untouched (no blank detail)', () => {
+    seedArchive('api', 5);
+    // 'ghost' has no archive readings; a stale detail must not be blanked.
+    writeEntityDetail(tmp, 'ghost', [reading('ghost', NOW - 40 * DAY)], new Date(NOW).toISOString());
+    regen(); // entities only lists 'api'
+    expect(readDetail('ghost').readings).toHaveLength(1); // preserved, not touched
+  });
+});

--- a/packages/probe/__tests__/update-incidents.test.ts
+++ b/packages/probe/__tests__/update-incidents.test.ts
@@ -10,7 +10,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {parseSummary} from '@stentorosaur/core';
 import type {IssuePayload} from '@stentorosaur/core';
-import {writeEntityDetail} from '../src/files';
+import {appendArchive, writeEntityDetail} from '../src/files';
 import {pushWithRegenerateRetry} from '../src/git-writer';
 import {readIncidentInputs} from '../src/inputs';
 import {regenerateDerived} from '../src/regenerate';
@@ -117,7 +117,12 @@ describe('probe-vs-issue-event race (§5)', () => {
       branch: 'status-data',
       commitMessage: 'probe: api readings',
       writeInputs: async dir => {
-        writeEntityDetail(dir, 'api', [{t: Date.parse(NOW) - 60_000, svc: 'api', state: 'up', code: 200, lat: 50}], NOW);
+        // Mirror the real probe (writeReadings): readings land in the
+        // append-only archives; regenerateDerived rebuilds the entity
+        // detail + summary window from there (#119).
+        const r = {t: Date.parse(NOW) - 60_000, svc: 'api', state: 'up' as const, code: 200, lat: 50};
+        appendArchive(dir, r);
+        writeEntityDetail(dir, 'api', [r], NOW);
       },
       regenerate: async dir => regenerateDerived(dir, REGEN),
       sleep: async () => {},

--- a/packages/probe/src/regenerate.ts
+++ b/packages/probe/src/regenerate.ts
@@ -11,9 +11,14 @@ import path from 'node:path';
 import {buildDailyRollups, buildSummary} from '@stentorosaur/core/server';
 import {incidentsToAtom} from '@stentorosaur/core/server';
 import type {EntityRef} from '@stentorosaur/core';
-import {readAllEntityDetails} from './files';
+import {writeEntityDetail} from './files';
 import {readArchiveReadings} from './archives';
 import {readIncidentInputs} from './inputs';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** Recent per-check window the entity-detail drill-down carries — kept
+ * in step with the r2 plane's CURRENT_WINDOW_DAYS. */
+const CURRENT_WINDOW_DAYS = 14;
 
 export interface RegenerateOptions {
   /** Injected timestamps keep buildSummary deterministic */
@@ -44,16 +49,27 @@ export function regenerateDerived(rootDir: string, options: RegenerateOptions): 
     );
   }
 
-  const details = readAllEntityDetails(rootDir);
-  const currentReadings = details.flatMap(d => d.readings);
+  // Read the FULL rollup window from the archives — the append-only
+  // source of truth. Nothing below modifies the archives; this only
+  // rebuilds DERIVED files from them.
   const archiveReadings = readArchiveReadings(rootDir, windowDays, generatedAtMs);
   const {incidents, maintenance} = readIncidentInputs(rootDir);
+
+  // The recent per-check window that the entity-detail drill-down and
+  // the summary's short-window stats read. Derived from the ARCHIVES,
+  // not from the on-disk entity details — the probe's writeReadings
+  // overwrites each detail with only its latest batch, so reading them
+  // back would collapse the window to a single point (#119). The r2
+  // plane already rebuilds details this way; this makes the git plane
+  // symmetric.
+  const windowStart = generatedAtMs - CURRENT_WINDOW_DAYS * DAY_MS;
+  const recent = archiveReadings.filter(r => r.t >= windowStart);
 
   const summary = buildSummary({
     generatedAt,
     generatedBy,
     entities,
-    readings: currentReadings,
+    readings: recent,
     dailyRollups: buildDailyRollups(archiveReadings),
     incidents,
     maintenance,
@@ -70,4 +86,18 @@ export function regenerateDerived(rootDir: string, options: RegenerateOptions): 
       updated: generatedAt,
     })
   );
+
+  // Rebuild each probed entity's detail from the recent window so the
+  // drill-down charts (Response Time, short-range Uptime/SLI) render
+  // real history instead of the single latest batch (#119). Entities
+  // with no readings in the window are left untouched — a process-only
+  // entity keeps having no detail file, and a temporarily-silent probed
+  // entity keeps its last good detail rather than being blanked.
+  for (const entity of entities) {
+    const detailReadings = recent
+      .filter(r => r.svc === entity.name)
+      .sort((a, b) => a.t - b.t);
+    if (detailReadings.length === 0) continue;
+    writeEntityDetail(rootDir, entity.name, detailReadings, generatedAt);
+  }
 }


### PR DESCRIPTION
Closes #119 (follow-up to #114).

## Root cause

The drill-down charts (Performance Metrics modal + per-entity history page) rendered a single "Data Points: 1" reading. On the **git data plane**, the probe's `writeReadings` overwrites each entity detail with **only its latest batch**, and `regenerateDerived` never rebuilt it — so the drill-down window collapsed to one point after the first probe cycle. The **R2 plane already rebuilds** the detail from the recent window every cycle (`regenerateDerivedR2`); the git plane was asymmetric. (Confirmed: `writeReadings` is byte-identical across probe 0.1.1→0.2.0 — not a version regression; the collapse is triggered by the probe running.)

## Fix

**A — server (root cause):** git-plane `regenerateDerived` now rebuilds each entity detail from the **recent 14-day archive window every cycle**, and sources the summary's recent-window stats from the archives too — symmetric with the R2 plane, self-healing on the next probe. **No monitoring data is lost:** the archives are the append-only source of truth and are never modified (a test asserts they're byte-identical after regenerate). Entities with no readings in the window are left untouched (process-only entities keep no detail; a temporarily-silent probe keeps its last good detail).

**B — client:** the Performance Metrics modal's long-range Uptime/SLI now fill from the 90-day daily series via the shared `mergeDaysIntoHistory` (StatusPage passes the entity's `days` to the modal), matching the history page from #114. Response Time stays on per-check readings (daily rollups carry no latency).

Together: Response Time + short-range Uptime/SLI render real history everywhere (from the restored 14-day detail window), and long-range Uptime/SLI fill 90 days in both the modal and history page.

## Tests (5 new)

- `regenerate-entity-detail.test.ts`: restores the 14-day window from archives even when the detail was collapsed to 1 point; **archives byte-identical after regenerate (no data loss)**; an entity with no window readings is left untouched.
- `PerformanceMetrics.test.tsx`: the modal's Uptime fills (≥6 of 7 daily bars) when `days` are present vs ≤1 without.
- `update-incidents.test.ts` fixture updated to seed the archives (as the real probe's `writeReadings` does) — proving the summary window now derives from the source of truth.

## Gates

core 76 / probe 183 / plugin 338; `tsc --build` clean; **e2e git 16/16 and r2 16/16**.

Note: this is a probe + plugin behavior change; it ships in the next release. Existing git-plane sites self-heal on the next probe cycle after upgrade (details rebuild from the intact archives).