### PR TITLE
chore(release): v1.1.1 (plugin 1.1.1 · probe 0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-16
+
+Accompanied by `@stentorosaur/probe` 0.2.1 (the entity-detail rebuild is
+in the probe's `regenerateDerived`). `@stentorosaur/core` is unchanged at
+0.2.0. The v1 workflow templates pin `@stentorosaur/probe@0.2.1`.
+
 ### Fixed
 
 - Drill-down charts (Performance Metrics modal + per-entity history page)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24522,7 +24522,7 @@
     },
     "packages/docusaurus-plugin-stentorosaur": {
       "name": "@amiable-dev/docusaurus-plugin-stentorosaur",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "^3.0.0",
@@ -24554,7 +24554,7 @@
     },
     "packages/probe": {
       "name": "@stentorosaur/probe",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@stentorosaur/core": "^0.2.0",

--- a/packages/docusaurus-plugin-stentorosaur/package.json
+++ b/packages/docusaurus-plugin-stentorosaur/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amiable-dev/docusaurus-plugin-stentorosaur",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Docusaurus plugin for displaying status monitoring dashboard powered by GitHub Issues and Actions, similar to Upptime",
   "main": "lib/index.js",
   "types": "src/plugin-status.d.ts",

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/probe-dispatch-v1.yml
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/probe-dispatch-v1.yml
@@ -47,5 +47,5 @@ jobs:
         run: |
           # PINNED version (supply-chain: this workflow holds
           # contents:write). Bump deliberately when upgrading the plugin.
-          npx -y -p @stentorosaur/probe@0.2.0 stentorosaur ingest \
+          npx -y -p @stentorosaur/probe@0.2.1 stentorosaur ingest \
             --payload /tmp/dispatch-payload.json

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/probe-v1.yml
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/probe-v1.yml
@@ -42,5 +42,5 @@ jobs:
         run: |
           # PINNED version (supply-chain: this workflow holds
           # contents:write). Bump deliberately when upgrading the plugin.
-          npx -y -p @stentorosaur/probe@0.2.0 \
+          npx -y -p @stentorosaur/probe@0.2.1 \
             stentorosaur probe --config . --workdir . --branch status-data

--- a/packages/docusaurus-plugin-stentorosaur/templates/workflows/status-update-v1.yml
+++ b/packages/docusaurus-plugin-stentorosaur/templates/workflows/status-update-v1.yml
@@ -46,5 +46,5 @@ jobs:
         run: |
           # PINNED version (supply-chain: this workflow holds
           # contents:write). Bump deliberately when upgrading the plugin.
-          npx -y -p @stentorosaur/probe@0.2.0 \
+          npx -y -p @stentorosaur/probe@0.2.1 \
             stentorosaur update-incidents --config . --workdir . --branch status-data

--- a/packages/probe/package.json
+++ b/packages/probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stentorosaur/probe",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Monitoring engine and I/O for Stentorosaur (ADR-005 §1). All fetching (HTTP checks, GitHub API, git writes) lives here; transforms live in @stentorosaur/core.",
   "license": "MIT",
   "author": "Amiable Development <dev@amiable.dev>",


### PR DESCRIPTION
Release prep for **v1.1.1** — a patch shipping the #119 drill-down chart fix. Publishes on GitHub Release (publish.yml).

## Versions
- `@amiable-dev/docusaurus-plugin-stentorosaur` 1.1.0 → **1.1.1**
- `@stentorosaur/probe` 0.2.0 → **0.2.1** (the `regenerateDerived` entity-detail rebuild lives here)
- `@stentorosaur/core` **unchanged at 0.2.0** — #119 touched no `core/src` (grep-verified); publish.yml skips the already-published core.

## What ships
- **#119**: git-plane `regenerateDerived` rebuilds each entity detail from the 14-day archive window (symmetric with R2, archives never modified), and the Performance Metrics modal's long-range Uptime/SLI fill from the 90-day daily series. Response Time + short-range charts now render real history in the modal and history page.

## Load-bearing beyond version numbers
- Template pins moved to `@stentorosaur/probe@0.2.1` so the fix (in the probe's regenerate) reaches sites via the workflow templates.
- `@stentorosaur/core: ^0.2.0` ranges unchanged (core stays 0.2.0 — still satisfied).
- `package-lock.json` synced.

## Validation (mirrors publish.yml)
- `npm run build --workspaces` clean; `npm test --workspaces`: core 76 / probe 183 / plugin 338.

After merge: tag `v1.1.1` + GitHub Release → publish.yml publishes probe 0.2.1 → plugin 1.1.1 (core 0.2.0 skipped).