### PR TITLE
feat: render performance charts inline under the expanded card (minimal layout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Minimal status board: a system's performance charts now render
+  inline directly under that card's 90-day bar when the card is
+  expanded**, instead of in a single panel at the bottom of the board.
+  Expanding a card is now an accordion (one open at a time) and its
+  Response Time / Uptime / SLI / Error Budget charts appear in place —
+  clicks inside the charts no longer collapse the card. The `upptime`
+  view and the `detailed` card layout are unchanged (the detailed
+  layout keeps the board-level panel). Consumers who swizzled the
+  status page purely to inline the charts can drop that customization.
+
 ## [1.1.1] - 2026-07-16
 
 Accompanied by `@stentorosaur/probe` 0.2.1 (the entity-detail rebuild is

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/StatusPage.test.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/StatusPage.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import StatusPage, {deriveV1BaseUrl, entitySlug, detailToSystemFile} from '../src/theme/StatusPage';
 import {makeSummary, makeStatusData} from './helpers/v1-fixtures';
@@ -152,6 +152,56 @@ describe('StatusPage (v1)', () => {
         expect.anything()
       )
     );
+  });
+
+  it('renders the charts INLINE under the expanded card (minimal layout), not at board bottom', async () => {
+    const summary = makeSummary({entities: [{name: 'api', status: 'up'}]});
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          schemaVersion: 1,
+          generatedAt: summary.generatedAt,
+          name: 'api',
+          readings: [{t: Date.parse(summary.generatedAt), svc: 'api', state: 'up', code: 200, lat: 50}],
+        }),
+    });
+
+    render(<StatusPage statusData={makeStatusData(summary, {dataUrl: '/status-data/status/v1/summary.json'})} />);
+    fireEvent.click(screen.getByRole('button', {name: /Toggle api/i}));
+
+    const panel = await screen.findByText(/Performance Metrics - api/i);
+    // Exactly one metrics panel, and it lives INSIDE the api card's
+    // <article> (proves inline placement, not the board-bottom panel).
+    expect(screen.getAllByText(/Performance Metrics - api/i)).toHaveLength(1);
+    const article = panel.closest('article');
+    expect(article).not.toBeNull();
+    expect(within(article!).getByRole('heading', {name: 'api'})).toBeInTheDocument();
+  });
+
+  it('a click inside the inline charts does not collapse the card', async () => {
+    const summary = makeSummary({entities: [{name: 'api', status: 'up'}]});
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          schemaVersion: 1,
+          generatedAt: summary.generatedAt,
+          name: 'api',
+          readings: [{t: Date.parse(summary.generatedAt), svc: 'api', state: 'up', code: 200, lat: 50}],
+        }),
+    });
+
+    render(<StatusPage statusData={makeStatusData(summary, {dataUrl: '/status-data/status/v1/summary.json'})} />);
+    fireEvent.click(screen.getByRole('button', {name: /Toggle api/i}));
+    const panel = await screen.findByText(/Performance Metrics - api/i);
+
+    // Click within the charts panel — must not toggle the card shut.
+    fireEvent.click(panel);
+    expect(screen.getByText(/Performance Metrics - api/i)).toBeInTheDocument();
+    expect(panel.closest('article')).toHaveAttribute('aria-expanded', 'true');
   });
 });
 

--- a/packages/docusaurus-plugin-stentorosaur/__tests__/StatusPage.test.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/__tests__/StatusPage.test.tsx
@@ -180,6 +180,38 @@ describe('StatusPage (v1)', () => {
     expect(within(article!).getByRole('heading', {name: 'api'})).toBeInTheDocument();
   });
 
+  it('expanding another card collapses the first (accordion: one open at a time)', async () => {
+    const summary = makeSummary({
+      entities: [
+        {name: 'api', status: 'up'},
+        {name: 'web', status: 'up'},
+      ],
+    });
+    (global as any).fetch = jest.fn().mockImplementation(async (url: string) => ({
+      ok: true,
+      status: 200,
+      text: async () => {
+        const name = url.includes('/web.json') ? 'web' : 'api';
+        return JSON.stringify({
+          schemaVersion: 1,
+          generatedAt: summary.generatedAt,
+          name,
+          readings: [{t: Date.parse(summary.generatedAt), svc: name, state: 'up', code: 200, lat: 50}],
+        });
+      },
+    }));
+
+    render(<StatusPage statusData={makeStatusData(summary, {dataUrl: '/status-data/status/v1/summary.json'})} />);
+
+    fireEvent.click(screen.getByRole('button', {name: /Toggle api/i}));
+    await screen.findByText(/Performance Metrics - api/i);
+
+    // Expanding 'web' must collapse 'api' — only one panel at a time.
+    fireEvent.click(screen.getByRole('button', {name: /Toggle web/i}));
+    await screen.findByText(/Performance Metrics - web/i);
+    expect(screen.queryByText(/Performance Metrics - api/i)).not.toBeInTheDocument();
+  });
+
   it('a click inside the inline charts does not collapse the card', async () => {
     const summary = makeSummary({entities: [{name: 'api', status: 'up'}]});
     (global as any).fetch = jest.fn().mockResolvedValue({

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
@@ -184,7 +184,14 @@ function StatusPageInner({
             <p>No systems configured for monitoring.</p>
           </div>
         ) : (
-          items.map(item => (
+          items.map(item => {
+            // Resolved once: the loaded detail for THIS card while it is
+            // the expanded one (undefined otherwise).
+            const inlineFile =
+              showPerformanceMetrics && activeSystem === item.name
+                ? systemFiles.get(item.name)
+                : undefined;
+            return (
             <SystemCard
               key={item.name}
               name={item.name}
@@ -210,25 +217,24 @@ function StatusPageInner({
                   <p>{item.description}</p>
                 </SystemCardDetails>
               )}
-              {showPerformanceMetrics &&
-                activeSystem === item.name &&
-                systemFiles.get(item.name) && (
-                  <SystemCardCharts>
-                    {/* Stop clicks inside the charts (period buttons,
-                        enlarge) from bubbling to the card's toggle. */}
-                    <div onClick={e => e.stopPropagation()}>
-                      <PerformanceMetrics
-                        systemFile={systemFiles.get(item.name)!}
-                        incidents={incidents}
-                        maintenance={maintenance}
-                        isVisible={true}
-                        onClose={() => setActiveSystem(null)}
-                      />
-                    </div>
-                  </SystemCardCharts>
-                )}
+              {inlineFile && (
+                <SystemCardCharts>
+                  {/* Stop clicks inside the charts (period buttons,
+                      enlarge) from bubbling to the card's toggle. */}
+                  <div onClick={e => e.stopPropagation()}>
+                    <PerformanceMetrics
+                      systemFile={inlineFile}
+                      incidents={incidents}
+                      maintenance={maintenance}
+                      isVisible={true}
+                      onClose={() => setActiveSystem(null)}
+                    />
+                  </div>
+                </SystemCardCharts>
+              )}
             </SystemCard>
-          ))
+            );
+          })
         )}
       </div>
     </div>

--- a/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
+++ b/packages/docusaurus-plugin-stentorosaur/src/theme/StatusPage/index.tsx
@@ -13,7 +13,7 @@ import StatusBoard from '../StatusBoard';
 import IncidentHistory from '../IncidentHistory';
 import MaintenanceList from '../Maintenance/MaintenanceList';
 import PerformanceMetrics from '../PerformanceMetrics';
-import {SystemCard, SystemCardDetails, SystemCardUptimeBar} from '../SystemCard';
+import {SystemCard, SystemCardCharts, SystemCardDetails, SystemCardUptimeBar} from '../SystemCard';
 import {StatusDataProvider} from '../../context/StatusDataProvider';
 import type {StatusData, SystemStatusFile} from '../../types';
 import {parseEntityDetail} from '@stentorosaur/core';
@@ -191,9 +191,16 @@ function StatusPageInner({
               displayName={item.displayName}
               status={item.status}
               expandable
+              // Accordion controlled by activeSystem: expanding a card
+              // makes it the single active one so its charts render
+              // inline below its 90-day bar (others collapse).
+              expanded={showPerformanceMetrics ? activeSystem === item.name : undefined}
               onExpandChange={
                 showPerformanceMetrics
-                  ? expanded => expanded && handleSystemClick(item.name)
+                  ? expanded => {
+                      setActiveSystem(expanded ? item.name : null);
+                      if (expanded) void loadEntityDetail(item.name);
+                    }
                   : undefined
               }
             >
@@ -203,6 +210,23 @@ function StatusPageInner({
                   <p>{item.description}</p>
                 </SystemCardDetails>
               )}
+              {showPerformanceMetrics &&
+                activeSystem === item.name &&
+                systemFiles.get(item.name) && (
+                  <SystemCardCharts>
+                    {/* Stop clicks inside the charts (period buttons,
+                        enlarge) from bubbling to the card's toggle. */}
+                    <div onClick={e => e.stopPropagation()}>
+                      <PerformanceMetrics
+                        systemFile={systemFiles.get(item.name)!}
+                        incidents={incidents}
+                        maintenance={maintenance}
+                        isVisible={true}
+                        onClose={() => setActiveSystem(null)}
+                      />
+                    </div>
+                  </SystemCardCharts>
+                )}
             </SystemCard>
           ))
         )}
@@ -230,7 +254,10 @@ function StatusPageInner({
             (statusCardLayout === 'minimal' ? renderMinimalLayout() : renderDetailedLayout())}
         </StatusDataProvider>
 
-        {showPerformanceMetrics && activeFile && (
+        {/* Minimal layout renders each system's charts INLINE under its
+            card (above). The detailed layout keeps the single
+            board-level panel below the board. */}
+        {statusCardLayout !== 'minimal' && showPerformanceMetrics && activeFile && (
           <PerformanceMetrics
             systemFile={activeFile}
             incidents={incidents}


### PR DESCRIPTION
Requested by the amiable.dev consumer: show a system's charts **directly under its 90-day bar when the card is expanded**, so they can drop their swizzle and get it by upgrading.

## Current vs new

- **Before:** the minimal board rendered `PerformanceMetrics` **once at the bottom of `<main>`**, keyed by `activeSystem` — the charts appeared at the page bottom, disconnected from the card you clicked.
- **After:** each system's charts render **inline inside the expanded card**, after its `SystemCardUptimeBar`, using the `SystemCard.Charts` compound sub-component that ADR-004 already defined for exactly this. Expanding is now an accordion (one card open at a time).

## Structural (this is the plugin's job)

- `StatusPage` minimal layout: the `SystemCard` is a controlled accordion (`expanded={activeSystem === name}`); on expand it becomes the single active system and its `PerformanceMetrics` renders in its children.
- Clicks inside the charts `stopPropagation` so the period selector / click-to-enlarge don't bubble to the card's `onClick` toggle and collapse it.
- The **board-bottom panel is retained only for the `detailed` card layout**; the `upptime` view (separate component) is untouched. So only the minimal-layout default changes.

## On not adding a feature flag (deliberate)

amiable.dev is the **only consumer of this plugin**. There is no installed base to protect from a default change, and the sole consumer is the one requesting this behaviour. A `metricsPlacement`/`inlineMetrics` option would be a flag with exactly zero users on its other branch — speculative generality, plus a second layout path to test and maintain forever. So this ships as the minimal-layout behaviour, unflagged. (An earlier revision of this description claimed the change was "trivially gateable behind an option"; that was a promise the code didn't make and shouldn't — removed.)

## Tests

- On expand, exactly one metrics panel renders and it lives **inside the expanded card's `<article>`** (proves inline, not board-bottom).
- Expanding a second card **collapses the first** (accordion mutual-exclusion).
- A click inside the charts keeps the card `aria-expanded="true"` (stopPropagation).

## Gates

plugin 341 (3 new) / core 76 / probe 183; `tsc --build` clean; **e2e git 16/16 and r2 16/16**.

## Out of scope (pre-existing, grep-confirmed not in this diff)

- `description: buildItem?.description` unconditionally overwrites the adapted summary description (asymmetric with the `displayName ?? …` fallback) — real bug, predates this PR.
- `loadEntityDetail` has no in-flight guard, so rapid expand/collapse can fire duplicate (idempotent, cached) GETs.

Both worth their own tickets rather than widening a layout PR.