### PR TITLE
chore(release): v1.2.0 (plugin 1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-17
+
+`@stentorosaur/core` (0.2.0) and `@stentorosaur/probe` (0.2.1) are
+unchanged — this release is plugin-only.
+
 ### Changed
 
 - **Minimal status board: a system's performance charts now render

--- a/package-lock.json
+++ b/package-lock.json
@@ -24522,7 +24522,7 @@
     },
     "packages/docusaurus-plugin-stentorosaur": {
       "name": "@amiable-dev/docusaurus-plugin-stentorosaur",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/packages/docusaurus-plugin-stentorosaur/package.json
+++ b/packages/docusaurus-plugin-stentorosaur/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amiable-dev/docusaurus-plugin-stentorosaur",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A Docusaurus plugin for displaying status monitoring dashboard powered by GitHub Issues and Actions, similar to Upptime",
   "main": "lib/index.js",
   "types": "src/plugin-status.d.ts",


### PR DESCRIPTION
Release prep for **v1.2.0** — minor, shipping the inline-charts layout (#122) so amiable.dev can consume it by upgrading.

## Versions
- `@amiable-dev/docusaurus-plugin-stentorosaur` 1.1.1 → **1.2.0**
- `@stentorosaur/core` **0.2.0** and `@stentorosaur/probe` **0.2.1** — unchanged (PR #122 was plugin-only, grep-confirmed); publish.yml skips them.

## What ships
- **#122**: on the minimal status board, a system's Response Time / Uptime / SLI / Error Budget charts now render **inline directly under that card's 90-day bar** when expanded, instead of in a panel at the bottom of the board. Expanding is an accordion (one open at a time); clicks inside the charts no longer collapse the card. `detailed` layout and the `upptime` view are unchanged.

Minor (not patch) because it changes the minimal board's behaviour.

## Notes
- Template pins stay at `@stentorosaur/probe@0.2.1` (probe unchanged).
- `package-lock.json` synced.

## Validation (mirrors publish.yml)
`npm run build --workspaces` clean; `npm test --workspaces`: core 76 / probe 183 / plugin 341.

After merge: tag `v1.2.0` + GitHub Release → publish.yml publishes the plugin (core/probe skipped).